### PR TITLE
fix(sec): validate upload content - PNG + size (#20)

### DIFF
--- a/terraform/lambda-functions/upload/index.js
+++ b/terraform/lambda-functions/upload/index.js
@@ -4,7 +4,38 @@ const s3Client = new S3Client({ region: process.env.AWS_DEFAULT_REGION });
 exports.handler = async (event) => {
   try {
     const body = JSON.parse(event.body);
+
+    // #20: 画像データの存在チェック
+    if (!body || typeof body.image !== 'string') {
+      return {
+        statusCode: 400,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ error: 'Missing image data' })
+      };
+    }
+
     const imageData = Buffer.from(body.image, 'base64');
+
+    // #20: サイズ上限（10MB）
+    const MAX_BYTES = 10 * 1024 * 1024;
+    if (imageData.length === 0 || imageData.length > MAX_BYTES) {
+      return {
+        statusCode: 400,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ error: 'Invalid image size' })
+      };
+    }
+
+    // #20: PNGマジックバイト(89 50 4E 47 0D 0A 1A 0A)を検証し、中身がPNG以外の保存を拒否
+    const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    if (imageData.length < 8 || !imageData.subarray(0, 8).equals(PNG_SIGNATURE)) {
+      return {
+        statusCode: 400,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ error: 'Uploaded data is not a valid PNG image' })
+      };
+    }
+
     const key = `${Date.now()}.png`;
 
     const command = new PutObjectCommand({


### PR DESCRIPTION
## What (resolves #20)
The upload Lambda stored any base64 payload with no validation. Add input checks in [upload/index.js](terraform/lambda-functions/upload/index.js):

- **Missing data** → 400 (`body.image` absent / not a string)
- **Size** → 400 if empty or **> 10MB**
- **Content type** → 400 if the first 8 bytes are not the **PNG signature** `89 50 4E 47 0D 0A 1A 0A` (rejects non-PNG content saved under a .png key)

Existing behaviour (key = `<timestamp>.png`, `GLACIER_IR`) is unchanged for valid PNGs.

## Verification
- `node --check` → OK (syntax valid).
- Pure Lambda source change; on apply only `aws_lambda_function.upload` updates (new source hash). **0 destroy.**
- No live `terraform plan` (dev container SSO expired); apply is the owner's local step.

## Owner steps
`aws sso login --profile dev` → `terraform plan` → `apply`. Then confirm: a real PNG via the iOS shortcut still returns 200; a non-PNG payload returns 400.