### PR TITLE
feat(metadata): U1 DynamoDB metadata foundation

### DIFF
--- a/scripts/backfill-metadata.sh
+++ b/scripts/backfill-metadata.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# U1: 既存画像(.png)を DynamoDB メタデータ基盤に「基本レコード」として投入する一度きりのスクリプト。
+# - imageId = S3キー(<timestamp>.png) / uploadedAt = ファイル名のtimestamp / visibility = private
+# - memo / autoTags / embedding は付けない（U2 のバックフィルで付与する）
+# - 既存レコードは上書きしない（attribute_not_exists 条件）。何度流しても安全。
+#
+# 前提: aws CLI + dev プロファイルでログイン済み（aws sso login --profile dev）。
+# 使い方: bash scripts/backfill-metadata.sh
+set -euo pipefail
+
+PROFILE="${AWS_PROFILE:-dev}"
+REGION="ap-northeast-1"
+TABLE="WIPUploader-ImageMetadata"
+BUCKET="wip-uploader-strage"
+
+echo "テーブル: $TABLE / バケット: $BUCKET / プロファイル: $PROFILE"
+
+# .png のキーだけを取得（viewer/ 配下の images.json 等は除外＝.pngで絞る）
+keys=$(aws s3api list-objects-v2 --bucket "$BUCKET" --profile "$PROFILE" --region "$REGION" \
+  --query "Contents[?ends_with(Key, '.png')].Key" --output text | tr '\t' '\n')
+
+total=0; added=0; skipped=0
+for key in $keys; do
+  [ -z "$key" ] && continue
+  total=$((total+1))
+  # ファイル名先頭の数値(10〜13桁)を uploadedAt に。取れなければ現在時刻(ms)。
+  ts=$(printf '%s' "$key" | grep -oE '^[0-9]{10,13}' || true)
+  [ -z "$ts" ] && ts=$(date +%s)000
+  if aws dynamodb put-item --table-name "$TABLE" --profile "$PROFILE" --region "$REGION" \
+       --item "{\"imageId\":{\"S\":\"$key\"},\"uploadedAt\":{\"N\":\"$ts\"},\"visibility\":{\"S\":\"private\"}}" \
+       --condition-expression "attribute_not_exists(imageId)" >/dev/null 2>&1; then
+    added=$((added+1))
+  else
+    skipped=$((skipped+1)) # 既存 or エラー
+  fi
+done
+
+echo "完了: 対象 $total 件 / 追加 $added 件 / スキップ(既存等) $skipped 件"

--- a/terraform/lambda-functions/update-images/index.js
+++ b/terraform/lambda-functions/update-images/index.js
@@ -1,7 +1,9 @@
 const { S3Client, ListObjectsV2Command, PutObjectCommand } = require('@aws-sdk/client-s3');
 const { CloudFront } = require('@aws-sdk/client-cloudfront');
+const { DynamoDBClient, ScanCommand } = require('@aws-sdk/client-dynamodb');
 
 const s3Client = new S3Client({ region: process.env.AWS_DEFAULT_REGION });
+const ddb = new DynamoDBClient({ region: process.env.AWS_DEFAULT_REGION });
 
 exports.handler = async (event) => {
   const imageBucket = process.env.IMAGE_BUCKET;
@@ -38,14 +40,45 @@ exports.handler = async (event) => {
     await s3Client.send(putObjectCommand);
     console.log("/"+fileName)
 
+    // U1: DynamoDB から公開メタデータを射影して metadata.json を生成。
+    // 公開フラグ付き(visibility=public)のメモだけを出し、非公開メモはCDNに出さない。
+    const metaItems = [];
+    let lastKey;
+    do {
+      const scan = await ddb.send(new ScanCommand({
+        TableName: process.env.METADATA_TABLE,
+        ExclusiveStartKey: lastKey,
+      }));
+      for (const it of scan.Items || []) metaItems.push(it);
+      lastKey = scan.LastEvaluatedKey;
+    } while (lastKey);
+
+    const metaPath = process.env.METADATA_JSON_PATH || 'viewer/metadata.json';
+    const publicMeta = metaItems.map((it) => {
+      const visibility = (it.visibility && it.visibility.S) || 'private';
+      return {
+        imageId: it.imageId && it.imageId.S,
+        uploadedAt: it.uploadedAt && it.uploadedAt.N ? Number(it.uploadedAt.N) : null,
+        autoTags: (it.autoTags && it.autoTags.SS) || [],
+        memo: visibility === 'public' && it.memo ? it.memo.S : null,
+      };
+    });
+    await s3Client.send(new PutObjectCommand({
+      Bucket: imageBucket,
+      Key: metaPath,
+      Body: JSON.stringify(publicMeta),
+      ContentType: 'application/json',
+    }));
+    console.log("/" + metaPath);
+
     const client = new CloudFront();
     await client.createInvalidation({
       DistributionId: process.env.DISTRIBUTION_ID,
       InvalidationBatch: {
         CallerReference: new Date().toISOString(),
         Paths: {
-          Quantity: 1,
-          Items: ["/" + fileName]
+          Quantity: 2,
+          Items: ["/" + fileName, "/" + metaPath]
         }
       }
     });

--- a/terraform/lambda-functions/upload/index.js
+++ b/terraform/lambda-functions/upload/index.js
@@ -1,5 +1,7 @@
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
+const { DynamoDBClient, PutItemCommand } = require('@aws-sdk/client-dynamodb');
 const s3Client = new S3Client({ region: process.env.AWS_DEFAULT_REGION });
+const ddb = new DynamoDBClient({ region: process.env.AWS_DEFAULT_REGION });
 
 exports.handler = async (event) => {
   try {
@@ -47,6 +49,21 @@ exports.handler = async (event) => {
     });
 
     await s3Client.send(command);
+
+    // U1: メタデータ基盤に基本レコードを作成（memo/tags/embedding は後続Unitで付与）。
+    // 失敗してもアップロードは成功扱い（後でバックフィル可能・後方互換を優先）。
+    try {
+      await ddb.send(new PutItemCommand({
+        TableName: process.env.METADATA_TABLE,
+        Item: {
+          imageId: { S: key },
+          uploadedAt: { N: String(Date.now()) },
+          visibility: { S: 'private' },
+        },
+      }));
+    } catch (e) {
+      console.error('metadata PutItem failed (upload succeeded):', e);
+    }
 
     return {
       statusCode: 200,

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -121,6 +121,26 @@ resource "aws_s3_bucket_lifecycle_configuration" "image_bucket" {
 }
 
 # =====================================================================================
+# DYNAMODB（Phase 1: 画像メタデータ基盤 / ADR-001）
+# =====================================================================================
+resource "aws_dynamodb_table" "image_metadata" {
+  name         = "${var.stack_name}-ImageMetadata"
+  billing_mode = "PAY_PER_REQUEST" # オンデマンド（無料枠内・運用ゼロ）
+  hash_key     = "imageId"         # = 既存の <timestamp>.png
+
+  attribute {
+    name = "imageId"
+    type = "S"
+  }
+
+  lifecycle {
+    prevent_destroy = true # メタデータ消失防止
+  }
+
+  tags = var.stack_tags
+}
+
+# =====================================================================================
 # CLOUDFRONT RESOURCES
 # =====================================================================================
 resource "aws_cloudfront_origin_access_control" "image_bucket" {
@@ -240,6 +260,12 @@ resource "aws_iam_role" "upload_lambda_execution" {
             "s3:PutObject"
           ]
           Resource = "${aws_s3_bucket.image_bucket.arn}/*"
+        },
+        {
+          # U1: アップロード時にメタデータ基本レコードを作成
+          Effect   = "Allow"
+          Action   = ["dynamodb:PutItem"]
+          Resource = aws_dynamodb_table.image_metadata.arn
         }
       ]
     })
@@ -334,6 +360,12 @@ resource "aws_iam_role" "update_lambda_execution" {
             "cloudfront:CreateInvalidation"
           ]
           Resource = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/${aws_cloudfront_distribution.main.id}"
+        },
+        {
+          # U1: 公開メタデータ射影(metadata.json生成)のためテーブルをScan
+          Effect   = "Allow"
+          Action   = ["dynamodb:Scan"]
+          Resource = aws_dynamodb_table.image_metadata.arn
         }
       ]
     })
@@ -359,6 +391,7 @@ resource "aws_lambda_function" "upload" {
     variables = {
       BUCKET_NAME      = aws_s3_bucket.image_bucket.id
       CLOUDFRONT_DOMAIN = aws_cloudfront_distribution.main.domain_name
+      METADATA_TABLE    = aws_dynamodb_table.image_metadata.name
     }
   }
 
@@ -399,6 +432,8 @@ resource "aws_lambda_function" "update_images_json" {
       IMAGE_BUCKET               = var.image_bucket_name
       DISTRIBUTION_ID           = var.cloudfront_distribution_id
       IMAGES_JSON_FILENAME_PATH = var.images_json_filename_path
+      METADATA_TABLE            = aws_dynamodb_table.image_metadata.name
+      METADATA_JSON_PATH        = "viewer/metadata.json"
     }
   }
 


### PR DESCRIPTION
## What — Construction U1（メタデータ基盤）
Phase 1 の土台。DynamoDBに1画像=1レコードのメタデータを持たせ、**公開分のみ**を新JSONに射影する。

- **DynamoDB** `WIPUploader-ImageMetadata`（PK `imageId`, オンデマンド, prevent_destroy）
- **upload Lambda**: S3保存後に `{imageId, uploadedAt, visibility:private}` を PutItem（try/catchで失敗してもアップロードは成功扱い＝後方互換）
- **update-images Lambda**: DynamoDBをScanし **公開フィールドだけ** を `viewer/metadata.json` に射影（`visibility=public` のmemoのみ出力＝**非公開メモはCDNに出さない**）。既存 `images.json` は維持（後方互換）
- **IAM**: upload に `dynamodb:PutItem`、update-images に `dynamodb:Scan`（テーブル限定）
- **scripts/backfill-metadata.sh**: 既存.pngの基本レコードを投入する一度きりスクリプト（冪等）

## 検証
- Lambda `node --check` OK / `terraform validate` OK
- `terraform plan` = **1 add / 5 change / 0 destroy**（DynamoDB新規＋IAM/Lambda更新）

## オーナー手順
1. `terraform plan` 確認 → `terraform apply`
2. 既存分を投入: `bash scripts/backfill-metadata.sh`（apply後・一度きり）
3. 確認: 新規アップロード→DynamoDBにレコード／`viewer/metadata.json` 生成

## スコープ
フロントは未変更（`metadata.json` は新ファイル、消費は U3/U4）。memo/autoTags/embedding は U2 以降で付与。