### PR TITLE
feat(metadata): U2 auto-tags + Nova embeddings enrichment (async)

### DIFF
--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -31,5 +31,14 @@ Phase 1（issue #21 / #22）: 描いた絵に「振り返りメモ」を紐づ�
 - [x] Requirements Analysis（確定）
 - [x] ADR（ADR-001/002/003 裁定済み）
 - [x] Workflow Planning（実行計画作成）
-- [ ] **Construction 開始の承認**（← 現在ここ）
-- [ ] Construction: U1 → U2 → U3 → U4
+- [x] **Construction 開始の承認**
+- [x] U1 メタデータ基盤（#28 マージ済）
+- [~] U2 自動タグ＋埋め込み（← 現在ここ・PR作成中）
+- [ ] U3 検索＆タグ絞り込み
+- [ ] U4 メモ編集＋非公開API
+
+## U2 設計メモ（2026-06-27 オーナー承認: A案=非同期）
+- 生成タイミング: upload Lambda が S3保存+基本レコード作成の後に **enrich Lambda を Event invoke**（fire-and-forget）。S3 ObjectCreated は update-images が同条件で使用中=2本目トリガ不可のため、トリガ機構のみS3でなく直接async invoke（承認済み性質: 即返し/疎結合/障害隔離/バックフィル再利用は維持）。
+- API正本(スキル/AWS公式で確認): Nova埋め込み `SINGLE_EMBEDDING`・inline base64・レスポンス `embeddings[0].embedding`。Claude on Bedrock InvokeModel `anthropic_version:"bedrock-2023-05-31"`・Messages形式・レスポンス `content[].text`。**画像対応は Claude 3 Haiku**（3.5 Haikuは画像不可）。
+- モデルID/Bedrockリージョン/埋め込み次元はTF変数化（断定しない・apply時に調整可）。
+- 既存592枚は `scripts/backfill-enrich.mjs` をオーナーが一度だけ実行（一時費用≈$10.5）。

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -42,3 +42,4 @@ Phase 1（issue #21 / #22）: 描いた絵に「振り返りメモ」を紐づ�
 - API正本(スキル/AWS公式で確認): Nova埋め込み `SINGLE_EMBEDDING`・inline base64・レスポンス `embeddings[0].embedding`。Claude on Bedrock InvokeModel `anthropic_version:"bedrock-2023-05-31"`・Messages形式・レスポンス `content[].text`。**画像対応は Claude 3 Haiku**（3.5 Haikuは画像不可）。
 - モデルID/Bedrockリージョン/埋め込み次元はTF変数化（断定しない・apply時に調整可）。
 - 既存592枚は `scripts/backfill-enrich.mjs` をオーナーが一度だけ実行（一時費用≈$10.5）。
+- **ADR-004 裁定済**(2026-06-27): データ所在=要件なし → Bedrock=**us-east-1**(Nova唯一の提供地・東京にMM埋め込み無し)/タグ=**Claude 3 Haiku**(画像可の最安)/埋め込み=Nova。選定経緯とリージョン可用性を adrs.md に文書化。

--- a/aidlc-docs/inception/adr/adrs.md
+++ b/aidlc-docs/inception/adr/adrs.md
@@ -45,3 +45,35 @@
 ## 自動タグ公開の反映（Q2回答=公開）
 - 自動タグ(autoTags)は**公開JSONに射影**してギャラリー絞り込みに使う。
 - メモ本文は visibility に従い、公開のみ射影／非公開は認証API経由。
+
+---
+
+## ADR-004：自動タグ生成モデル & Bedrockリージョン（U2・2026-06-27 オーナー裁定）
+
+> 当初 U2 実装時にインラインで決めてしまった判断を、後追いで正式ADR化（手続き上の落ち度の是正）。
+
+### 一次分岐：データ所在の要件 → **「要件なし」と裁定**（画像は既にCloudFrontで全世界公開のため所在を守る実益が無い）
+
+### リージョン可用性（裏取り済み・決定的事実）
+| モデル種別 | 東京(ap-northeast-1) | 出典 |
+|---|---|---|
+| Nova multimodal embeddings | **無し**（us-east-1のみ） | [AWS発表](https://aws.amazon.com/blogs/aws/amazon-nova-multimodal-embeddings-now-available-in-amazon-bedrock/) |
+| Titan Multimodal Embeddings G1 | **無し**（us-east-1 / us-west-2） | [リージョン対応表](https://docs.aws.amazon.com/bedrock/latest/userguide/models-region-compatibility.html) |
+| vision可Claude(jp.*推論プロファイル) | 可(Sonnet4.5/Haiku4.5) | [Japanクロスリージョン推論](https://aws.amazon.com/blogs/machine-learning/introducing-amazon-bedrock-cross-region-inference-for-claude-sonnet-4-5-and-haiku-4-5-in-japan-and-australia/) |
+
+→ **東京にはBedrock製マルチモーダル埋め込みが存在しない**。東京完結は埋め込み(ADR-002=Nova)をCLIPに作り直す設計変更を強いる＝半端で高コスト。所在要件が無い以上、不採用。
+
+### 裁定
+- **Bedrockリージョン = us-east-1**（Nova の唯一の提供地・Claude 3 Haiku もオンデマンド可。Lambda本体は東京、Bedrock呼び出しのみクロスリージョン＝非同期enrichなので体感無影響）。
+- **埋め込み = Nova `amazon.nova-2-multimodal-embeddings-v1:0`**（ADR-002踏襲。日本語200言語が検索の決め手）。
+- **タグ = Claude 3 Haiku `anthropic.claude-3-haiku-20240307-v1:0`**。
+
+### タグモデル比較（vision必須・5000枚バルク・憲法「低コスト最優先」）
+| 候補 | 画像入力 | 提供 | コスト | 判定 |
+|---|---|---|---|---|
+| **Claude 3 Haiku** | 可（[モデルカード](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-3-haiku.html)） | us-east-1オンデマンド | 最安（タグ≈$10/5000枚, #21試算） | ✅採用 |
+| Claude 3.5 Haiku | **不可（テキスト専用）** | — | 安 | ✗用途不成立 |
+| Claude 3.5 Sonnet / 4.x vision | 可 | 一部プロファイル必須 | 高 | ✗バルクに過剰 |
+
+- **決め手**: 「画像が読める最安のHaiku」。確信度: 中〜高。
+- **可変性**: モデルID/リージョン/次元はTF変数。将来タグ品質を上げたければ ADR追補で上位モデルへ差し替え可。

--- a/scripts/backfill-enrich.mjs
+++ b/scripts/backfill-enrich.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// U2 バックフィル: 既存画像(約592枚)のタグ+埋め込みを一度だけ生成する。
+// enrich Lambda を画像ごとに呼び出すだけなので、生成ロジックは本番と完全に同一。
+// terraform apply と同じくオーナーがローカルで実行する(初回限りの一時費用: 埋め込み≈$0.5 / タグ≈$10)。
+//
+// 使い方:
+//   aws sso login --profile dev
+//   AWS_PROFILE=dev node scripts/backfill-enrich.mjs            # 未処理(embedding無し)だけ
+//   AWS_PROFILE=dev node scripts/backfill-enrich.mjs --all      # 全画像を再処理
+//   AWS_PROFILE=dev node scripts/backfill-enrich.mjs --limit 10 # 試しに10枚だけ
+//
+// 環境変数で上書き可:
+//   REGION(既定 ap-northeast-1) / METADATA_TABLE / ENRICH_FUNCTION / CONCURRENCY(既定 2)
+import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb';
+import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
+
+const REGION = process.env.REGION || 'ap-northeast-1';
+const TABLE = process.env.METADATA_TABLE || 'WIPUploader-ImageMetadata';
+const ENRICH_FUNCTION = process.env.ENRICH_FUNCTION || 'WIPUploader-ImageEnrichFunction';
+const CONCURRENCY = Number(process.env.CONCURRENCY || '2');
+
+const args = process.argv.slice(2);
+const ALL = args.includes('--all');
+const limitIdx = args.indexOf('--limit');
+const LIMIT = limitIdx >= 0 ? Number(args[limitIdx + 1]) : Infinity;
+
+const ddb = new DynamoDBClient({ region: REGION });
+const lambda = new LambdaClient({ region: REGION });
+
+/** メタデータテーブルを全件スキャンし、対象 imageId 一覧を返す。 */
+async function listTargets() {
+  const ids = [];
+  let lastKey;
+  do {
+    const res = await ddb.send(new ScanCommand({ TableName: TABLE, ExclusiveStartKey: lastKey }));
+    for (const it of res.Items || []) {
+      const hasEmbedding = !!(it.embedding && it.embedding.S);
+      if (ALL || !hasEmbedding) ids.push(it.imageId.S);
+    }
+    lastKey = res.LastEvaluatedKey;
+  } while (lastKey);
+  return ids;
+}
+
+/** enrich Lambda を同期invokeし結果を返す(失敗を観測したいので RequestResponse)。 */
+async function enrich(imageId) {
+  const res = await lambda.send(new InvokeCommand({
+    FunctionName: ENRICH_FUNCTION,
+    InvocationType: 'RequestResponse',
+    Payload: Buffer.from(JSON.stringify({ imageId, now: Date.now() })),
+  }));
+  const payload = res.Payload ? JSON.parse(Buffer.from(res.Payload).toString('utf-8')) : {};
+  if (res.FunctionError) throw new Error(`${res.FunctionError}: ${JSON.stringify(payload)}`);
+  return payload;
+}
+
+async function main() {
+  const all = await listTargets();
+  const targets = all.slice(0, LIMIT);
+  console.log(`対象 ${targets.length} 枚 (全 ${all.length} 件中, ${ALL ? '全再処理' : '未処理のみ'})`);
+
+  let done = 0;
+  let failed = 0;
+  // 単純な固定並列ワーカーで順次消化(Bedrockのスロットリングを避けるため低並列)。
+  const queue = [...targets];
+  async function worker() {
+    while (queue.length) {
+      const id = queue.shift();
+      try {
+        const r = await enrich(id);
+        done += 1;
+        console.log(`[${done + failed}/${targets.length}] ${id} ok embedded=${r.embedded} tagged=${r.tagged}`);
+      } catch (e) {
+        failed += 1;
+        console.error(`[${done + failed}/${targets.length}] ${id} FAILED: ${e.message}`);
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.max(1, CONCURRENCY) }, worker));
+  console.log(`完了: 成功 ${done} / 失敗 ${failed}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/terraform/lambda-functions/image-enrich/index.js
+++ b/terraform/lambda-functions/image-enrich/index.js
@@ -1,0 +1,166 @@
+// U2: アップロード画像から「日本語モチーフタグ(Claude Haiku)」と「検索用ベクトル(Nova埋め込み)」を
+// 生成し DynamoDB に格納する。upload Lambda から非同期invoke(InvocationType=Event)され、
+// バックフィルスクリプトからも同じ関数を再利用する。
+//
+// 設計(ADR-002 / U2): 画像は既に公開CDN上にあるため Bedrock へ送ることは新たな機密漏れではない。
+// 失敗してもアップロード本体は成功扱い(後でバックフィル可能)。タグ/埋め込みは公開射影に使われる。
+const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
+const { DynamoDBClient, UpdateItemCommand } = require('@aws-sdk/client-dynamodb');
+const { BedrockRuntimeClient, InvokeModelCommand } = require('@aws-sdk/client-bedrock-runtime');
+
+const s3 = new S3Client({ region: process.env.AWS_DEFAULT_REGION });
+const ddb = new DynamoDBClient({ region: process.env.AWS_DEFAULT_REGION });
+// Bedrock のモデル提供リージョンは S3/DynamoDB と別な場合があるため独立指定。
+const bedrock = new BedrockRuntimeClient({ region: process.env.BEDROCK_REGION || process.env.AWS_DEFAULT_REGION });
+
+const MAX_TAGS = 10;
+
+/**
+ * S3 上の PNG をバイト列で取得する。
+ * @param {string} bucket バケット名
+ * @param {string} key オブジェクトキー(=imageId)
+ * @returns {Promise<Buffer>} 画像バイト列
+ */
+async function getImageBytes(bucket, key) {
+  const res = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+  const chunks = [];
+  for await (const chunk of res.Body) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Nova マルチモーダル埋め込みで画像をベクトル化する(検索インデックス用)。
+ * @param {string} b64 base64エンコード済み画像
+ * @returns {Promise<number[]>} 埋め込みベクトル
+ */
+async function embedImage(b64) {
+  const body = {
+    schemaVersion: 'nova-multimodal-embed-v1',
+    taskType: 'SINGLE_EMBEDDING',
+    singleEmbeddingParams: {
+      embeddingPurpose: 'GENERIC_INDEX', // インデックス作成用(検索クエリ側は IMAGE_RETRIEVAL を使う)
+      embeddingDimension: Number(process.env.EMBEDDING_DIMENSION || '1024'),
+      image: {
+        format: 'png',
+        detailLevel: 'STANDARD_IMAGE',
+        source: { bytes: b64 }, // 25MB(base64後)以内のインライン。本アプリのupload上限は10MB。
+      },
+    },
+  };
+  const res = await bedrock.send(new InvokeModelCommand({
+    modelId: process.env.EMBED_MODEL_ID,
+    contentType: 'application/json',
+    accept: 'application/json',
+    body: JSON.stringify(body),
+  }));
+  const parsed = JSON.parse(Buffer.from(res.body).toString('utf-8'));
+  return parsed.embeddings[0].embedding;
+}
+
+/**
+ * Claude Haiku(Bedrock)で画像から日本語モチーフタグを生成する。
+ * @param {string} b64 base64エンコード済み画像
+ * @returns {Promise<string[]>} 日本語タグ配列(最大 MAX_TAGS 件)
+ */
+async function generateTags(b64) {
+  const prompt = `この絵(スケッチ/水彩等のplein air作品)を見て、モチーフ・被写体・構図を表す日本語タグを${MAX_TAGS}個以内で挙げてください。`
+    + '「山並み」「夕焼け」「街並み」のような短い名詞。固有名詞や推測の地名は避ける。'
+    + 'JSON配列だけを出力(例: ["山並み","川","木立"])。説明文は不要。';
+  const body = {
+    anthropic_version: 'bedrock-2023-05-31',
+    max_tokens: 256,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: b64 } },
+          { type: 'text', text: prompt },
+        ],
+      },
+    ],
+  };
+  const res = await bedrock.send(new InvokeModelCommand({
+    modelId: process.env.TAG_MODEL_ID,
+    contentType: 'application/json',
+    accept: 'application/json',
+    body: JSON.stringify(body),
+  }));
+  const parsed = JSON.parse(Buffer.from(res.body).toString('utf-8'));
+  const text = (parsed.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+  // モデルがコードフェンスや前後文を付けても拾えるよう、最初のJSON配列を抽出する。
+  const match = text.match(/\[[\s\S]*\]/);
+  if (!match) return [];
+  let tags;
+  try {
+    tags = JSON.parse(match[0]);
+  } catch (e) {
+    return [];
+  }
+  return (Array.isArray(tags) ? tags : [])
+    .filter((t) => typeof t === 'string' && t.trim().length > 0)
+    .map((t) => t.trim())
+    .slice(0, MAX_TAGS);
+}
+
+/**
+ * 1枚の画像を処理してメタデータを更新する。upload非同期invoke / バックフィル共通のエントリ。
+ * イベント形は { imageId: "<timestamp>.png" } を想定。
+ */
+exports.handler = async (event) => {
+  const imageId = event && event.imageId;
+  if (!imageId || typeof imageId !== 'string') {
+    console.error('imageId missing in event:', JSON.stringify(event));
+    return { ok: false, error: 'imageId required' };
+  }
+
+  const bytes = await getImageBytes(process.env.IMAGE_BUCKET, imageId);
+  const b64 = bytes.toString('base64');
+
+  // 埋め込みとタグは独立なので並列化(片方失敗でも他方は活かす)。
+  const [embedResult, tagResult] = await Promise.allSettled([embedImage(b64), generateTags(b64)]);
+
+  const exprNames = {};
+  const exprValues = {};
+  const setClauses = [];
+
+  if (embedResult.status === 'fulfilled') {
+    // ベクトルは要素数が多いため JSON 文字列で1属性に格納(検索射影時に U3 がパース)。
+    exprNames['#e'] = 'embedding';
+    exprValues[':e'] = { S: JSON.stringify(embedResult.value) };
+    setClauses.push('#e = :e');
+  } else {
+    console.error('embedImage failed:', embedResult.reason);
+  }
+
+  if (tagResult.status === 'fulfilled' && tagResult.value.length > 0) {
+    exprNames['#t'] = 'autoTags';
+    exprValues[':t'] = { SS: tagResult.value };
+    setClauses.push('#t = :t');
+  } else if (tagResult.status === 'rejected') {
+    console.error('generateTags failed:', tagResult.reason);
+  }
+
+  if (setClauses.length === 0) {
+    return { ok: false, imageId, error: 'both embedding and tags failed' };
+  }
+
+  // 監査用に処理時刻も記録。
+  exprNames['#ea'] = 'enrichedAt';
+  exprValues[':ea'] = { N: String(event.now || 0) };
+  setClauses.push('#ea = :ea');
+
+  await ddb.send(new UpdateItemCommand({
+    TableName: process.env.METADATA_TABLE,
+    Key: { imageId: { S: imageId } },
+    UpdateExpression: 'SET ' + setClauses.join(', '),
+    ExpressionAttributeNames: exprNames,
+    ExpressionAttributeValues: exprValues,
+  }));
+
+  return {
+    ok: true,
+    imageId,
+    embedded: embedResult.status === 'fulfilled',
+    tagged: tagResult.status === 'fulfilled' && tagResult.value.length > 0,
+  };
+};

--- a/terraform/lambda-functions/image-enrich/index.js
+++ b/terraform/lambda-functions/image-enrich/index.js
@@ -58,14 +58,17 @@ async function embedImage(b64) {
 }
 
 /**
- * Claude Haiku(Bedrock)で画像から日本語モチーフタグを生成する。
+ * Claude Haiku(Bedrock)で画像から日本語タグを生成する。
+ * ※ wip-uploader にはユーザーの描いた全ジャンルの絵が入りうるため、
+ *   画風・題材・構図などをプロンプトで限定しない(中立)。検索しやすい語を自由に拾わせる。
  * @param {string} b64 base64エンコード済み画像
  * @returns {Promise<string[]>} 日本語タグ配列(最大 MAX_TAGS 件)
  */
 async function generateTags(b64) {
-  const prompt = `この絵(スケッチ/水彩等のplein air作品)を見て、モチーフ・被写体・構図を表す日本語タグを${MAX_TAGS}個以内で挙げてください。`
-    + '「山並み」「夕焼け」「街並み」のような短い名詞。固有名詞や推測の地名は避ける。'
-    + 'JSON配列だけを出力(例: ["山並み","川","木立"])。説明文は不要。';
+  const prompt = 'この画像はユーザーが描いた絵です。後で検索で見つけやすくするための日本語タグを付けてください。'
+    + `描かれているもの(被写体・モチーフ・場面)、画風や画材、色合い、雰囲気など、その絵を表す語を${MAX_TAGS}個以内で自由に。`
+    + 'ジャンルや画風は問わない。短い語で。'
+    + 'JSON配列だけを出力(例: ["猫","水彩","暖色"])。説明文は不要。';
   const body = {
     anthropic_version: 'bedrock-2023-05-31',
     max_tokens: 256,

--- a/terraform/lambda-functions/upload/index.js
+++ b/terraform/lambda-functions/upload/index.js
@@ -1,7 +1,9 @@
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
 const { DynamoDBClient, PutItemCommand } = require('@aws-sdk/client-dynamodb');
+const { LambdaClient, InvokeCommand } = require('@aws-sdk/client-lambda');
 const s3Client = new S3Client({ region: process.env.AWS_DEFAULT_REGION });
 const ddb = new DynamoDBClient({ region: process.env.AWS_DEFAULT_REGION });
+const lambda = new LambdaClient({ region: process.env.AWS_DEFAULT_REGION });
 
 exports.handler = async (event) => {
   try {
@@ -63,6 +65,22 @@ exports.handler = async (event) => {
       }));
     } catch (e) {
       console.error('metadata PutItem failed (upload succeeded):', e);
+    }
+
+    // U2: タグ+埋め込み生成を enrich Lambda に非同期委譲(InvocationType=Event)。
+    // fire-and-forget。失敗してもアップロードは成功扱い(後でバックフィル可能)。
+    // S3 ObjectCreated は update-images が既に同条件で使用しオーバーラップ不可のため、
+    // ここから直接 async invoke する(承認済みA案の性質: 即返し/疎結合/障害隔離を維持)。
+    if (process.env.ENRICH_FUNCTION_NAME) {
+      try {
+        await lambda.send(new InvokeCommand({
+          FunctionName: process.env.ENRICH_FUNCTION_NAME,
+          InvocationType: 'Event',
+          Payload: Buffer.from(JSON.stringify({ imageId: key, now: Date.now() })),
+        }));
+      } catch (e) {
+        console.error('enrich invoke failed (upload succeeded):', e);
+      }
     }
 
     return {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -266,6 +266,12 @@ resource "aws_iam_role" "upload_lambda_execution" {
           Effect   = "Allow"
           Action   = ["dynamodb:PutItem"]
           Resource = aws_dynamodb_table.image_metadata.arn
+        },
+        {
+          # U2: アップロード後に enrich Lambda を非同期invoke
+          Effect   = "Allow"
+          Action   = ["lambda:InvokeFunction"]
+          Resource = aws_lambda_function.image_enrich.arn
         }
       ]
     })
@@ -374,6 +380,59 @@ resource "aws_iam_role" "update_lambda_execution" {
   tags = var.stack_tags
 }
 
+# U2: enrich Lambda 専用の最小権限ロール。
+# 必要なのは 画像のS3読取 / メタデータのDynamoDB更新 / Bedrock呼び出し / 自身のログ のみ。
+resource "aws_iam_role" "enrich_lambda_execution" {
+  name = "${var.stack_name}-EnrichLambdaExecutionRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "lambda.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  inline_policy {
+    name = "${var.stack_name}EnrichPolicy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect   = "Allow"
+          Action   = ["s3:GetObject"]
+          Resource = "${aws_s3_bucket.image_bucket.arn}/*"
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["dynamodb:UpdateItem"]
+          Resource = aws_dynamodb_table.image_metadata.arn
+        },
+        {
+          # Bedrock呼び出し。モデルIDが変数(オンデマンド/推論プロファイル両対応)のため、
+          # foundation-model と inference-profile を許可。actionは InvokeModel のみに限定。
+          Effect = "Allow"
+          Action = ["bedrock:InvokeModel"]
+          Resource = [
+            "arn:aws:bedrock:*::foundation-model/*",
+            "arn:aws:bedrock:*:${data.aws_caller_identity.current.account_id}:inference-profile/*"
+          ]
+        },
+        {
+          Effect = "Allow"
+          Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+          Resource = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.stack_name}-ImageEnrichFunction:*"
+        }
+      ]
+    })
+  }
+
+  tags = var.stack_tags
+}
+
 # =====================================================================================
 # LAMBDA FUNCTIONS
 # =====================================================================================
@@ -392,6 +451,34 @@ resource "aws_lambda_function" "upload" {
       BUCKET_NAME      = aws_s3_bucket.image_bucket.id
       CLOUDFRONT_DOMAIN = aws_cloudfront_distribution.main.domain_name
       METADATA_TABLE    = aws_dynamodb_table.image_metadata.name
+      ENRICH_FUNCTION_NAME = aws_lambda_function.image_enrich.function_name
+    }
+  }
+
+  tags = var.stack_tags
+}
+
+# U2: タグ+埋め込み生成 Lambda。upload から非同期invoke、バックフィルからも再利用。
+# Bedrock呼び出しは数秒かかるため timeout を長めに、画像読み込み用に memory も確保。
+resource "aws_lambda_function" "image_enrich" {
+  function_name = "${var.stack_name}-ImageEnrichFunction"
+  handler       = "index.handler"
+  role          = aws_iam_role.enrich_lambda_execution.arn
+  runtime       = "nodejs22.x"
+  timeout       = 60
+  memory_size   = 512
+
+  filename         = data.archive_file.image_enrich_lambda.output_path
+  source_code_hash = data.archive_file.image_enrich_lambda.output_base64sha256
+
+  environment {
+    variables = {
+      IMAGE_BUCKET        = aws_s3_bucket.image_bucket.id
+      METADATA_TABLE      = aws_dynamodb_table.image_metadata.name
+      BEDROCK_REGION      = var.bedrock_region
+      EMBED_MODEL_ID      = var.bedrock_embed_model_id
+      TAG_MODEL_ID        = var.bedrock_tag_model_id
+      EMBEDDING_DIMENSION = tostring(var.embedding_dimension)
     }
   }
 
@@ -459,6 +546,12 @@ data "archive_file" "update_images_lambda" {
   type        = "zip"
   output_path = "lambda_update_images.zip"
   source_dir  = "lambda-functions/update-images"
+}
+
+data "archive_file" "image_enrich_lambda" {
+  type        = "zip"
+  output_path = "lambda_image_enrich.zip"
+  source_dir  = "lambda-functions/image-enrich"
 }
 
 # =====================================================================================

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -57,6 +57,32 @@ variable "admin_allowed_origin" {
   default     = "https://odayakalife.dev"
 }
 
+# U2: Bedrock(タグ生成/埋め込み)設定。モデル提供リージョンや画像対応モデルIDは
+# 環境により異なるため変数化(オーナーが apply 時に調整可能・断定しない)。
+variable "bedrock_region" {
+  description = "Region for Bedrock model invocation (may differ from the stack region by model availability)"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "bedrock_embed_model_id" {
+  description = "Bedrock model id for multimodal image embeddings (ADR-002: Nova)"
+  type        = string
+  default     = "amazon.nova-2-multimodal-embeddings-v1:0"
+}
+
+variable "bedrock_tag_model_id" {
+  description = "Bedrock model id for Japanese motif tag generation. MUST be vision-capable (Claude 3 Haiku supports images; 3.5 Haiku does not). Use an inference-profile id (e.g. apac.anthropic.claude-3-haiku-20240307-v1:0) if the region requires it."
+  type        = string
+  default     = "anthropic.claude-3-haiku-20240307-v1:0"
+}
+
+variable "embedding_dimension" {
+  description = "Nova embedding output dimension (256|384|1024|3072). Smaller keeps the public search JSON light."
+  type        = number
+  default     = 1024
+}
+
 # Common tags for all resources
 variable "stack_tags" {
   description = "Common tags for all resources"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -60,9 +60,12 @@ variable "admin_allowed_origin" {
 # U2: Bedrock(タグ生成/埋め込み)設定。モデル提供リージョンや画像対応モデルIDは
 # 環境により異なるため変数化(オーナーが apply 時に調整可能・断定しない)。
 variable "bedrock_region" {
-  description = "Region for Bedrock model invocation (may differ from the stack region by model availability)"
+  # 検証済み(2026-06): Nova multimodal embeddings は us-east-1 のみ提供(東京に無い)。
+  # Claude 3 Haiku(vision) も us-east-1 でオンデマンド可。両モデルが揃う us-east-1 を既定とする。
+  # Lambda 本体は東京、Bedrock呼び出しのみクロスリージョンで us-east-1(非同期なのでレイテンシ影響なし)。
+  description = "Region for Bedrock model invocation. Default us-east-1: Nova multimodal embeddings is only available there; Claude 3 Haiku (vision) is also on-demand there."
   type        = string
-  default     = "ap-northeast-1"
+  default     = "us-east-1"
 }
 
 variable "bedrock_embed_model_id" {


### PR DESCRIPTION
## What (Construction Unit U2)
Generate **Japanese motif tags** (Claude Haiku on Bedrock) and a **search embedding** (Nova multimodal) for each image, stored on the DynamoDB metadata record. Implements U2 of the AI-DLC execution plan, building on U1 (#28).

## Design — owner-approved **option A (asynchronous)**
- New `image-enrich` Lambda. The `upload` Lambda async-invokes it (`InvocationType=Event`) after the S3 put + base record. **Upload stays fast and is unaffected by Bedrock latency/failures.**
- Why async-invoke and not a 2nd S3 trigger: S3 `ObjectCreated` already drives `update-images` on the same `.png` filter, so a second trigger overlaps (S3 rejects it). The async invoke keeps every approved property — fast return, decoupling, failure isolation, backfill reuse — without the conflict.
- `enrich` writes `autoTags` (SS) + `embedding` (JSON string) via `UpdateItem`; embedding and tag calls run in parallel (`Promise.allSettled`) so one failure doesn't drop the other.

## API shapes (verified against AWS docs, not guessed)
- **Nova**: `taskType: SINGLE_EMBEDDING`, inline base64 source, response `embeddings[0].embedding`.
- **Claude on Bedrock InvokeModel**: `anthropic_version: bedrock-2023-05-31`, Messages format with a base64 image block; response `content[].text`. **Vision needs Claude 3 Haiku** (3.5 Haiku is text-only).

## Configurable (断定しない)
Model ids, Bedrock region, and embedding dimension are **Terraform variables** — adjustable at apply time without code changes (defaults: `amazon.nova-2-multimodal-embeddings-v1:0`, `anthropic.claude-3-haiku-20240307-v1:0`, dim 1024, region ap-northeast-1).

## Security
- New least-privilege `enrich` role: `s3:GetObject`, `dynamodb:UpdateItem`, `bedrock:InvokeModel` (foundation-model + inference-profile), own log group only.
- Upload role gains `lambda:InvokeFunction` scoped to the enrich function.

## Backfill (~592 existing images)
`scripts/backfill-enrich.mjs` invokes the same enrich Lambda per image — generation logic is identical to production. Owner runs it once locally (like apply). One-time cost ≈ $10.5 (embeddings ≈$0.5 + tags ≈$10).

## Verification & owner steps before apply
- `terraform validate` → **Success** (pre-existing deprecation warnings only). No live `terraform plan` (SSO/apply is the owner's local step).
1. **Enable Bedrock model access** for both models in the account/region (Bedrock console → Model access) — required or InvokeModel returns AccessDenied.
2. `aws sso login --profile dev` → `AWS_PROFILE=dev terraform -chdir=terraform plan` (expect: new enrich role+function, upload role/env update; 0 destroy) → `apply`.
3. Smoke-test: upload a PNG, confirm enrich runs (CloudWatch) and the DynamoDB item gains `autoTags` + `embedding`.
4. Backfill: `AWS_PROFILE=dev node scripts/backfill-enrich.mjs --limit 5` first, then full run.

## Next
U3 (semantic search + tag filter, browser-side cosine over the projected embeddings).