### PR TITLE
fix(u2): tag model -> Amazon Nova Lite (Claude 3 Haiku is Legacy/dead)

### DIFF
--- a/aidlc-docs/inception/adr/adrs.md
+++ b/aidlc-docs/inception/adr/adrs.md
@@ -77,3 +77,18 @@
 
 - **決め手**: 「画像が読める最安のHaiku」。確信度: 中〜高。
 - **可変性**: モデルID/リージョン/次元はTF変数。将来タグ品質を上げたければ ADR追補で上位モデルへ差し替え可。
+
+### ADR-004 改定（2026-06-27・us-east-1 実機検証で上記タグ裁定を覆す）
+机上のモデルカードを信じた当初裁定が**実機で破綻**したため改定。AdministratorAccess で us-east-1 に実 InvokeModel して確認した結果：
+
+| モデル | 実機結果 |
+|---|---|
+| `amazon.nova-2-multimodal-embeddings-v1:0`（埋め込み） | ✅ 同期InvokeModel成功（`embeddings[0].embedding` 返却）。モデルカードの「Invoke非対応」表記は誤り。**埋め込みは変更なし**。 |
+| `anthropic.claude-3-haiku-20240307-v1:0`（旧タグ裁定） | ❌ `ResourceNotFoundException`「This Model is marked by provider as **Legacy** … upgrade to an active model」＝**呼べない** |
+| `anthropic.claude-3-5-sonnet-*`（20240620/20241022, 直/us.） | ❌ 全て「model version has reached **end of life**」 |
+| `us.anthropic.claude-haiku-4-5-*` / `us.anthropic.claude-sonnet-4-5-*` | △ active だが「**Model use case details have not been submitted**」＝アカウントへ Anthropic 用途フォーム提出が必須（コンソール操作・オーナーのみ可）＋`us.`プロファイル必須 |
+| **`amazon.nova-lite-v1:0`**（新タグ裁定） | ✅ **画像→日本語タグJSONを即返却**（用途フォーム不要・低コスト・マルチモーダル・多言語）。実応答例: `["カフェ","コーヒー","食器","テーブル","カップ"]` |
+
+**改定裁定（タグ生成）= `amazon.nova-lite-v1:0`**。理由: Anthropic系は全滅(Legacy/EOL)か用途フォーム待ち(=オーナー操作でブロック)で**今すぐ動かない**。Nova Lite は提出不要で即動作・低コスト・画像入力対応＝憲法「低コスト最優先」にも合致。
+- enrich は `TAG_MODEL_ID` 接頭辞で body 形式を分岐（`amazon.nova*`=messages-v1 / それ以外=Anthropic Messages）。用途フォーム提出後に Claude Haiku 4.5（`us.` プロファイル）へ変数差し替え可能。
+- **教訓**: 可用性・APIサポートはモデルカードを鵜呑みにせず実 InvokeModel で確認する（埋め込みの「Invoke非対応」表記も実機では誤りだった）。

--- a/terraform/lambda-functions/image-enrich/index.js
+++ b/terraform/lambda-functions/image-enrich/index.js
@@ -58,38 +58,65 @@ async function embedImage(b64) {
 }
 
 /**
- * Claude Haiku(Bedrock)で画像から日本語タグを生成する。
+ * Bedrock のマルチモーダルLLMで画像から日本語タグを生成する。
  * ※ wip-uploader にはユーザーの描いた全ジャンルの絵が入りうるため、
  *   画風・題材・構図などをプロンプトで限定しない(中立)。検索しやすい語を自由に拾わせる。
+ *
+ * モデルにより InvokeModel の body/応答形式が異なるため TAG_MODEL_ID の接頭辞で分岐:
+ *  - amazon.nova-*  : Nova messages-v1 形式(用途フォーム不要・現状の既定)
+ *  - それ以外(Claude): Anthropic Messages 形式(要 Anthropic 用途フォーム提出)
+ * 検証(2026-06, us-east-1 実機): Claude 3 Haiku は Legacy 化で呼べず、Claude 4.5系は
+ * アカウントへの Anthropic 用途フォーム提出が必須。Nova Lite は提出不要で即動作するため既定に採用。
  * @param {string} b64 base64エンコード済み画像
  * @returns {Promise<string[]>} 日本語タグ配列(最大 MAX_TAGS 件)
  */
 async function generateTags(b64) {
+  const modelId = process.env.TAG_MODEL_ID;
   const prompt = 'この画像はユーザーが描いた絵です。後で検索で見つけやすくするための日本語タグを付けてください。'
     + `描かれているもの(被写体・モチーフ・場面)、画風や画材、色合い、雰囲気など、その絵を表す語を${MAX_TAGS}個以内で自由に。`
     + 'ジャンルや画風は問わない。短い語で。'
     + 'JSON配列だけを出力(例: ["猫","水彩","暖色"])。説明文は不要。';
-  const body = {
-    anthropic_version: 'bedrock-2023-05-31',
-    max_tokens: 256,
-    messages: [
-      {
-        role: 'user',
-        content: [
-          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: b64 } },
-          { type: 'text', text: prompt },
+
+  const isNova = modelId.startsWith('amazon.nova');
+  const body = isNova
+    ? {
+        schemaVersion: 'messages-v1',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { image: { format: 'png', source: { bytes: b64 } } },
+              { text: prompt },
+            ],
+          },
         ],
-      },
-    ],
-  };
+        inferenceConfig: { maxTokens: 256 },
+      }
+    : {
+        anthropic_version: 'bedrock-2023-05-31',
+        max_tokens: 256,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'image', source: { type: 'base64', media_type: 'image/png', data: b64 } },
+              { type: 'text', text: prompt },
+            ],
+          },
+        ],
+      };
   const res = await bedrock.send(new InvokeModelCommand({
-    modelId: process.env.TAG_MODEL_ID,
+    modelId,
     contentType: 'application/json',
     accept: 'application/json',
     body: JSON.stringify(body),
   }));
   const parsed = JSON.parse(Buffer.from(res.body).toString('utf-8'));
-  const text = (parsed.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+  // Nova: output.message.content[].text / Claude: content[].text
+  const blocks = isNova
+    ? ((parsed.output && parsed.output.message && parsed.output.message.content) || [])
+    : (parsed.content || []);
+  const text = blocks.filter((b) => typeof b.text === 'string').map((b) => b.text).join('');
   // モデルがコードフェンスや前後文を付けても拾えるよう、最初のJSON配列を抽出する。
   const match = text.match(/\[[\s\S]*\]/);
   if (!match) return [];

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -75,9 +75,14 @@ variable "bedrock_embed_model_id" {
 }
 
 variable "bedrock_tag_model_id" {
-  description = "Bedrock model id for Japanese motif tag generation. MUST be vision-capable (Claude 3 Haiku supports images; 3.5 Haiku does not). Use an inference-profile id (e.g. apac.anthropic.claude-3-haiku-20240307-v1:0) if the region requires it."
+  # 検証(2026-06, us-east-1 実機): Claude 3 Haiku は Legacy 化で InvokeModel 不可、
+  # Claude 3.5系は EOL、Claude 4.5系(Haiku/Sonnet)は active だがアカウントへの Anthropic
+  # 用途フォーム提出が必須。Amazon Nova Lite は提出不要で即動作・低コスト・画像入力対応のため既定に採用。
+  # Claude に切替える場合は用途フォーム提出後、us.* 推論プロファイルID
+  # (例: us.anthropic.claude-haiku-4-5-20251001-v1:0) を指定。enrich は model id 接頭辞で body 形式を分岐。
+  description = "Bedrock model id for Japanese tag generation. MUST be vision-capable. Default amazon.nova-lite-v1:0 (no Anthropic use-case form, low cost, image-capable). For Claude, submit the Anthropic use-case form and set a us.* inference-profile id."
   type        = string
-  default     = "anthropic.claude-3-haiku-20240307-v1:0"
+  default     = "amazon.nova-lite-v1:0"
 }
 
 variable "embedding_dimension" {


### PR DESCRIPTION
## Why — live-tested, not assumed
Invoked Bedrock **us-east-1** directly (AdministratorAccess). The prior tag model is broken:

| model | live result |
|---|---|
| `anthropic.claude-3-haiku-20240307-v1:0` (prior choice) | ❌ `ResourceNotFoundException`: 'marked by provider as **Legacy** … upgrade to an active model' |
| `anthropic.claude-3-5-sonnet-*` (all dates, direct + `us.`) | ❌ 'model version has reached **end of life**' |
| `us.anthropic.claude-haiku-4-5-*` / `sonnet-4-5-*` | △ active but 'Model **use case details have not been submitted**' (account-level Anthropic form, owner-only console action) |
| **`amazon.nova-lite-v1:0`** | ✅ works now, no form, multimodal, returns JP tag JSON e.g. `["カフェ","コーヒー",…]` |
| `amazon.nova-2-multimodal-embeddings-v1:0` (embeddings) | ✅ synchronous InvokeModel works (model card's 'Invoke not supported' is **wrong**) |

## Change
- Default `bedrock_tag_model_id` → **`amazon.nova-lite-v1:0`** (no Anthropic form, low cost, image-capable, JP-capable).
- `generateTags` branches on model id: `amazon.nova*` → Nova `messages-v1` body (`output.message.content[].text`); else → Anthropic Messages body (`content[].text`). So the owner can switch to Claude Haiku 4.5 (`us.*` profile) after submitting the use-case form, just by changing the variable.
- **Embeddings unchanged** (Nova embeddings verified live).
- ADR-004 amended with the live findings + lesson (verify with real InvokeModel, not the model card).

## Verified
- `node --check` (enrich) OK; `terraform validate` Success.
- Nova Lite image→tag and Nova embeddings both confirmed with real us-east-1 invokes.

## Apply note
Anthropic use-case form is **no longer needed** for the default path (Nova). Owner just needs Bedrock reachable in us-east-1 (already confirmed: AdministratorAccess invoked both Nova models successfully).