### PR TITLE
feat(viewer): U3a tag filtering (frontend only)

### DIFF
--- a/aidlc-docs/HANDOVER.md
+++ b/aidlc-docs/HANDOVER.md
@@ -1,0 +1,69 @@
+# 引き継ぎ書 — sketch-stacker Phase 1（2026-06-27 時点）
+
+## 0. 一言サマリ
+描いた絵に「振り返りメモ＋自動タグ＋意味検索」を足す Phase 1。
+**Inception 完了 / Construction U1・U2 は本番反映＆実機検証済み / U3 着手中（U3a=タグ絞り込みは PR #32）/ U4 未着手。**
+
+---
+
+## 1. リポジトリ構成 / デプロイ
+- repo: `trkoh/sketch-stacker`
+- バックエンド: `terraform/`（AWS・Terraform が正本。apply はオーナー）
+- フロント: `viewer-react/`（React+Vite）→ **GitHub Pages へ自動デプロイ**（`.github/workflows/deploy.yml`：main への push で build→Pages 公開。PRでは公開しない）
+- AI-DLC 運用ドキュメント: `aidlc-docs/`（`aidlc-state.md` 状態 / `audit.md` 監査 / `inception/` 要件・ADR・計画）
+
+## 2. インフラ実値（確定・実コード由来）
+| 項目 | 値 |
+|---|---|
+| AWSアカウント / stackリージョン / profile | `791464527050` / `ap-northeast-1` / `dev`（AWS SSO） |
+| **Bedrockリージョン** | **`us-east-1`**（Nova埋め込みは us-east-1 のみ。Lambdaは東京、Bedrock呼び出しだけクロスリージョン） |
+| DynamoDB | `WIPUploader-ImageMetadata`（hash_key=`imageId`=`<timestamp>.png`） |
+| Lambda | upload=`WIPUploader-UploadFunction-hJDSjvqD9eM7` / authorizer=`WIPUploader-AuthorizerFunction-7WKXvtdhJ2Lx` / update-images=`WIPUploaderUpdateImagesJsonFunction` / delete / enrich=`WIPUploader-ImageEnrichFunction` |
+| S3バケット | `wip-uploader-strage` |
+| API | `https://3p4utkstnb.execute-api.ap-northeast-1.amazonaws.com/prod`（`POST /upload`, `DELETE /images/{key}`） |
+| 認証 | Basic認証。Secret=`WIPUploaderSecret`（JSONキー `secret_key`=パスワード）、username=authorizer env `AUTH_USERNAME`（=`terakou`） |
+| CloudFront | `d3a21s3joww9j4.cloudfront.net`（`images.json`, `viewer/metadata.json`） |
+
+> ⚠️ 別スタック `ImageUploader*`（`image-uploader-strage` 等）は別アプリ **image-share-app** のもの。**触るな・消すな**（[[aws-two-stacks-live-wip]]）。
+
+## 3. データフロー
+1. **upload**（API＋Basic認証, body `{"image":"<base64 PNG>"}`）→ PNG検証(#20) → S3保存 → DDB基本レコード作成（`visibility=private`）→ **enrich を非同期invoke**（fire-and-forget）。
+2. **enrich** → S3から画像取得 → **Nova埋め込み(1024次元)** ＋ **Nova Liteタグ(日本語)** を並列生成 → DDB `UpdateItem`（`embedding`=JSON文字列, `autoTags`=SS, `enrichedAt`）。失敗してもuploadは成功扱い（後でバックフィル可）。
+3. **S3 ObjectCreated(.png)** → **update-images** → `images.json`（キー配列）＋ `viewer/metadata.json`（`imageId/uploadedAt/autoTags/memo`※memoは公開のみ）を生成し CloudFront invalidate。
+4. **フロント** → `images.json`＋`metadata.json` を取得し表示（U3aでタグ絞り込み）。
+
+## 4. 進捗（AI-DLC / Construction）
+- Inception 完了：requirements / ADR-001〜004 / 実行計画（`aidlc-docs/inception/`）
+- **U1 メタ基盤**（PR #28）反映済
+- **U2 自動タグ＋埋め込み**（#29）＋ 依存バンドル（#30）＋ タグモデル修正（#31）反映済・**実機検証済**
+  - 実証: 実画像 enrich→`embedded:true/tagged:true`、DDBに日本語タグ10個＋1024次元ベクトル、API upload→自動enrich連鎖も確認
+- **U3 検索**：U3a タグ絞り込み=**PR #32 オープン（未マージ）**。U3b 意味検索=**未着手**
+- **U4 メモ編集＋非公開API**：**未着手**
+
+## 5. 重要な決定・ハマりどころ（必読）
+- **ADR-004（タグモデル）= `amazon.nova-lite-v1:0`**。理由（**実機検証で判明**）：`anthropic.claude-3-haiku-20240307-v1:0` は **Legacy化で InvokeModel 不可**、Claude 3.5系は **EOL**、Claude 4.5系（`us.anthropic.claude-haiku-4-5-*` 等）は active だが **アカウントへの Anthropic 用途フォーム提出が必須**（オーナーのコンソール操作）。Nova Lite は用途フォーム不要・即動作・低コスト・画像入力対応。
+  - enrich は `TAG_MODEL_ID` 接頭辞で body 形式を分岐：`amazon.nova*`=Nova `messages-v1`（応答 `output.message.content[].text`）/ それ以外=Anthropic Messages（応答 `content[].text`）。用途フォーム提出後は変数を `us.anthropic.claude-haiku-4-5-20251001-v1:0` 等に変えるだけで Claude に切替可。
+- **埋め込み= `amazon.nova-2-multimodal-embeddings-v1:0`**、**同期InvokeModelで動く**（モデルカードの「Invoke非対応」表記は**誤り**＝実機で確認）。次元=1024（TF変数 `embedding_dimension`）。DDBには **JSON文字列**で格納（U3でパースして使う）。
+- **教訓: モデルの可用性/APIサポートはモデルカードを鵜呑みにせず、実 InvokeModel で確認すること。**
+- **ADR-002（検索方式）= Nova埋め込み＋ブラウザ内コサイン総当たり**（小規模ゆえベクトルDB不要）。
+- 全モデルID/Bedrockリージョン/次元は **TF変数**（`terraform/variables.tf`）で差し替え可。
+- **Lambda依存同梱（#30）**：Node22ランタイムのSDK同梱は AWS保証外 → `upload`/`image-enrich` は `package.json`＋`package-lock.json`＋`terraform_data` の `npm ci` で同梱。**apply実行ホストに node/npm 必須**。
+- **AWS SSOトークンは失効する**（数分〜数日）。AWS操作前に必ず `aws sso login --profile dev`。
+- **terraform state はローカル**（S3 backend 未設定）。消失・ロック無しに注意。
+
+## 6. 残作業（優先順）
+1. **PR #32（U3aタグ絞り込み）レビュー→マージ**。main マージで Pages 自動デプロイ。※ `metadata.json` にタグが載るのは **enrich済み画像のみ**＝バックフィル前はタグが少ない。
+2. **バックフィル（既存592枚）**：`aws sso login --profile dev` → `AWS_PROFILE=dev REGION=ap-northeast-1 node scripts/backfill-enrich.mjs --limit 5`（試走）→ 全量。**一時費用 ≈ $10.5**（埋め込み≈$0.5＋タグ≈$10）。
+3. **U3b 意味検索**：(a) update-images に embedding 射影（**別ファイル `viewer/embeddings.json` 推奨**＝ギャラリー軽量化・検索時に遅延ロード）(b) **クエリ埋め込みLambda＋APIルート**（Nova text 埋め込み・`embeddingPurpose=IMAGE_RETRIEVAL`・dim1024）(c) フロント検索ボックス＋ブラウザ内コサイン。
+   - 設計判断（検索エンドポイントを**公開**にするか**オーナー限定(既存authorizer)**にするか＝コスト/悪用リスク）は **ADR-005 で裁定推奨**（憲法「断定しない」）。
+4. **U4 メモ編集＋非公開API**：`GET/PUT /memos`（Basic認証・既存authorizer再利用＝ADR-003）。管理UI（`?admin`）にメモ編集＋公開トグル。
+5. （任意）terraform state を S3 backend 化。残セキュリティ #14–20 は完了済み。
+
+## 7. 役割分担
+- **オーナーのみ**：`terraform apply`、`aws sso login`、Anthropic用途フォーム提出、バックフィル実行（費用発生）、PRマージ。
+- **エージェント**：設計・実装・PR作成・`terraform plan` 提示・実機検証（SSO有効時）。main 直pushしない。
+
+## 8. 動作確認の要点（apply後）
+- enrich直接: `aws lambda invoke --function-name WIPUploader-ImageEnrichFunction --payload '{"imageId":"<key>"}' ...`
+- DDB確認: `aws dynamodb get-item --table-name WIPUploader-ImageMetadata --key '{"imageId":{"S":"<key>"}}'` → `embedding`(JSON文字列)/`autoTags`(SS)/`enrichedAt` を確認
+- 全文手順はセッション履歴の「apply手順 STEP0〜8」を参照。

--- a/viewer-react/src/components/ImageGallery.jsx
+++ b/viewer-react/src/components/ImageGallery.jsx
@@ -6,12 +6,14 @@ import Masonry from 'react-masonry-css';
 
 const ImageGallery = () => {
   const [images, setImages] = useState([]);
-  const [displayedImages, setDisplayedImages] = useState([]);
-  const [showAll, setShowAll] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(20);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalImageUrl, setModalImageUrl] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  // U3a タグ絞り込み: metadata.json(U1射影) の autoTags を imageId->tags で保持。
+  const [tagsById, setTagsById] = useState({});
+  const [selectedTags, setSelectedTags] = useState([]); // AND 絞り込み（選択タグを全て含む画像のみ）
   // 管理モード: 認証情報はメモリ上のみ保持（localStorageには残さない＝再読込で消える）
   const [admin, setAdmin] = useState(null);
   const [adminForm, setAdminForm] = useState({ open: false, username: '', password: '' });
@@ -21,6 +23,7 @@ const ImageGallery = () => {
   // 設定
   const BASE_URL = "https://d3a21s3joww9j4.cloudfront.net/";
   const JSON_URL = "https://d3a21s3joww9j4.cloudfront.net/viewer/images.json";
+  const META_URL = "https://d3a21s3joww9j4.cloudfront.net/viewer/metadata.json";
   const API_BASE = "https://3p4utkstnb.execute-api.ap-northeast-1.amazonaws.com/prod";
   const EXCLUDE = ["viewer/", "viewer/index.html", "viewer/images.json"];
   const INITIAL_COUNT = 20;
@@ -29,17 +32,20 @@ const ImageGallery = () => {
     fetchImages();
   }, []);
 
+  // タグ選択が変わったら表示件数をリセット（先頭から見せ直す）
+  useEffect(() => {
+    setVisibleCount(INITIAL_COUNT);
+  }, [selectedTags]);
+
   const fetchImages = async () => {
     try {
       setLoading(true);
-      const response = await fetch(JSON_URL, {
-        method: 'GET',
-        mode: 'cors',
-        credentials: 'omit',
-        headers: {
-          'Accept': 'application/json',
-        }
-      });
+      // 画像一覧(images.json)とメタデータ(metadata.json=autoTags)を並行取得。
+      // metadata.json はU1射影。未生成/失敗でもギャラリーは画像一覧だけで成立させる。
+      const [response, metaRes] = await Promise.all([
+        fetch(JSON_URL, { method: 'GET', mode: 'cors', credentials: 'omit', headers: { 'Accept': 'application/json' } }),
+        fetch(META_URL, { method: 'GET', mode: 'cors', credentials: 'omit', headers: { 'Accept': 'application/json' } }).catch(() => null),
+      ]);
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -50,8 +56,24 @@ const ImageGallery = () => {
         .filter(name => !EXCLUDE.includes(name))
         .sort((a, b) => b.localeCompare(a)); // 降順（新しい順）
 
+      // metadata.json から imageId -> autoTags を構築（取得できた場合のみ）
+      if (metaRes && metaRes.ok) {
+        try {
+          const meta = await metaRes.json();
+          const map = {};
+          for (const m of Array.isArray(meta) ? meta : []) {
+            if (m && m.imageId && Array.isArray(m.autoTags) && m.autoTags.length) {
+              map[m.imageId] = m.autoTags;
+            }
+          }
+          setTagsById(map);
+        } catch (e) {
+          console.warn('metadata.json の解析に失敗（タグ絞り込みなしで継続）', e);
+        }
+      }
+
       setImages(filteredFiles);
-      setDisplayedImages(filteredFiles.slice(0, INITIAL_COUNT));
+      setVisibleCount(INITIAL_COUNT);
     } catch (err) {
       console.error("画像リスト取得失敗", err);
       setError(err.message);
@@ -60,14 +82,12 @@ const ImageGallery = () => {
     }
   };
 
-  const handleLoadMore = () => {
-    const currentCount = displayedImages.length;
-    const nextBatch = images.slice(currentCount, currentCount + INITIAL_COUNT);
-    setDisplayedImages([...displayedImages, ...nextBatch]);
+  const toggleTag = (tag) => {
+    setSelectedTags(prev => prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]);
+  };
 
-    if (currentCount + INITIAL_COUNT >= images.length) {
-      setShowAll(true);
-    }
+  const handleLoadMore = () => {
+    setVisibleCount(c => c + INITIAL_COUNT);
   };
 
   const handleImageClick = (imageUrl) => {
@@ -110,7 +130,6 @@ const ImageGallery = () => {
       }
       // 成功したらUIから即座に除去
       setImages(prev => prev.filter(n => n !== imageName));
-      setDisplayedImages(prev => prev.filter(n => n !== imageName));
     } catch (err) {
       console.error("削除失敗", err);
       alert(`削除に失敗しました: ${err.message}`);
@@ -125,7 +144,26 @@ const ImageGallery = () => {
     return <div>Error: {error}</div>;
   }
 
-  const hasMoreImages = !showAll && images.length > INITIAL_COUNT;
+  // 選択タグ(AND)で絞り込み。選択が無ければ全件。
+  const filteredImages = selectedTags.length === 0
+    ? images
+    : images.filter(name => {
+        const tags = tagsById[name];
+        return tags && selectedTags.every(t => tags.includes(t));
+      });
+  const displayedImages = filteredImages.slice(0, visibleCount);
+  const hasMoreImages = displayedImages.length < filteredImages.length;
+
+  // タグチップ用: 出現頻度の高い順に上位を提示（多すぎる時の足切り）。選択中タグは常に含める。
+  const TAG_CHIP_LIMIT = 40;
+  const tagCounts = {};
+  for (const name of images) {
+    for (const t of tagsById[name] || []) tagCounts[t] = (tagCounts[t] || 0) + 1;
+  }
+  const topTags = Object.keys(tagCounts)
+    .sort((a, b) => tagCounts[b] - tagCounts[a] || a.localeCompare(b))
+    .slice(0, TAG_CHIP_LIMIT);
+  const chipTags = Array.from(new Set([...selectedTags, ...topTags]));
 
   const breakpointColumns = {
     default: 6,
@@ -190,6 +228,37 @@ const ImageGallery = () => {
       {/* Contribution Calendar */}
       <ContributionCalendar images={images} />
 
+      {/* U3a タグ絞り込み: 自動タグ(autoTags)のチップ。クリックでAND絞り込み。タグが無ければ非表示。 */}
+      {chipTags.length > 0 && (
+        <div className="tag-filter" style={{ display: 'flex', flexWrap: 'wrap', gap: 6, margin: '10px 0', alignItems: 'center' }}>
+          {selectedTags.length > 0 && (
+            <button
+              onClick={() => setSelectedTags([])}
+              style={{ padding: '4px 10px', borderRadius: 14, border: '1px solid #ccc', background: '#fff', cursor: 'pointer', fontSize: '0.8rem' }}
+            >
+              クリア（{filteredImages.length}件）
+            </button>
+          )}
+          {chipTags.map(tag => {
+            const on = selectedTags.includes(tag);
+            return (
+              <button
+                key={tag}
+                onClick={() => toggleTag(tag)}
+                style={{
+                  padding: '4px 10px', borderRadius: 14, cursor: 'pointer', fontSize: '0.8rem',
+                  border: on ? '1px solid #2d7' : '1px solid #ddd',
+                  background: on ? '#2d7' : '#f5f5f5',
+                  color: on ? '#fff' : '#333',
+                }}
+              >
+                {tag}{tagCounts[tag] ? ` (${tagCounts[tag]})` : ''}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
       <Masonry
         breakpointCols={breakpointColumns}
         className="gallery"
@@ -212,7 +281,7 @@ const ImageGallery = () => {
           className="load-more"
           onClick={handleLoadMore}
         >
-          Load More ({Math.min(INITIAL_COUNT, images.length - displayedImages.length)} more)
+          Load More ({Math.min(INITIAL_COUNT, filteredImages.length - displayedImages.length)} more)
         </button>
       )}
 


### PR DESCRIPTION
Consume viewer/metadata.json (U1 projection) for a client-side tag filter: tag chips (top-N by frequency), click to AND-narrow the gallery. No backend, no Bedrock cost. lint 0 errors, vite build passes. Semantic search = U3b (separate).