### PR TITLE
fix(u2): dedupe auto-tags before DynamoDB String Set (enrich was silently failing)

### DIFF
--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -35,9 +35,9 @@ Phase 1（issue #21 / #22）: 描いた絵に「振り返りメモ」を紐づ�
 - [x] U1 メタデータ基盤（#28 マージ済）
 - [x] U2 自動タグ＋埋め込み（#29/#30/#31 マージ済・実機検証済）
 - [x] U3a タグ絞り込み（#32 マージ済・Pages デプロイ成功 2026-06-28）
-- [~] U3b 意味検索（PR作成・ADR-005=A オーナー限定で実装。query-embed Lambda＋POST /search＋embeddings.json 射影＋フロント検索。terraform plan / lint / build 通過。apply はオーナー）
+- [x] U3b 意味検索（#34 マージ・apply・実機検証済 2026-06-28）
 - [ ] U4 メモ編集＋非公開API（未着手・ADR-003 で authorizer 再利用裁定済）
-- [ ] バックフィル（既存592枚 enrich・費用≈$10.5・オーナー実行）← U3a/U3b を実用にする前提
+- [~] バックフィル（2026-06-28 実行）: 469枚 embedding / 464枚 tagged を本番反映（metadata.json 518件中タグ付き464、embeddings.json 469件）。**残49枚は enrich の重複タグバグで失敗**＝fix/enrich-dedup-tags で修正、apply 後に再実行で回収。
 
 ## U2 設計メモ（2026-06-27 オーナー承認: A案=非同期）
 - 生成タイミング: upload Lambda が S3保存+基本レコード作成の後に **enrich Lambda を Event invoke**（fire-and-forget）。S3 ObjectCreated は update-images が同条件で使用中=2本目トリガ不可のため、トリガ機構のみS3でなく直接async invoke（承認済み性質: 即返し/疎結合/障害隔離/バックフィル再利用は維持）。

--- a/terraform/lambda-functions/image-enrich/index.js
+++ b/terraform/lambda-functions/image-enrich/index.js
@@ -126,10 +126,13 @@ async function generateTags(b64) {
   } catch (e) {
     return [];
   }
-  return (Array.isArray(tags) ? tags : [])
+  // モデルは同じ語を重複して返すことがある。autoTags は DynamoDB の String Set(SS) に格納するが
+  // SS は重複を許さず、重複があると UpdateItem 全体が ValidationException で失敗する(埋め込みも巻き添えで落ちる)。
+  // よってここで重複を除去してから返す。
+  const cleaned = (Array.isArray(tags) ? tags : [])
     .filter((t) => typeof t === 'string' && t.trim().length > 0)
-    .map((t) => t.trim())
-    .slice(0, MAX_TAGS);
+    .map((t) => t.trim());
+  return [...new Set(cleaned)].slice(0, MAX_TAGS);
 }
 
 /**


### PR DESCRIPTION
## バグ
タグモデル(Nova Lite)が**重複タグ**を返すことがある（実例: `["山","影","雪","霧","霧","霧",…]` / `["風景画",…,"風景画"]`）。autoTags は DynamoDB の **String Set (SS)** で保存するが、SS は重複を許さず `ValidationException` で **UpdateItem が丸ごと失敗** → 同じ UpdateItem に乗っている **embedding も巻き添えで書かれない**。結果、その画像はタグも検索ベクトルも付かない。

**本番の新規アップロードでも発生する潜在バグ**（enrich は fire-and-forget なので upload は 200 のまま静かに失敗）。

## 検出経緯
全量バックフィル（515枚）で発覚。約**49枚**がこの重複タグで失敗し embedding 無しのまま残った（スロットリングではなかった）。

## 修正
`generateTags` の返り値を **Set で重複除去**してから返す（[image-enrich/index.js](terraform/lambda-functions/image-enrich/index.js)）。1関数・8行。

## apply 後の回収手順（オーナー）
```
# apply 後、残り約49枚を回収
aws sso login --profile dev
AWS_PROFILE=dev REGION=ap-northeast-1 CONCURRENCY=1 node scripts/backfill-enrich.mjs
aws lambda invoke --function-name WIPUploaderUpdateImagesJsonFunction --payload '{}' \
  --cli-binary-format raw-in-base64-out --profile dev --region ap-northeast-1 /tmp/upd.json
```

## 現状（バックフィル成果・本番反映済み）
- **embeddings.json 469件**（意味検索の母集団）/ **metadata.json タグ付き464件**。3件→469件に拡大済み。
- 残49枚はこの修正の apply＋再実行で 100% 近くまで回収見込み（一部は画像破損等で残る可能性）。