### PR TITLE
feat(u4): reflection memo editing + private memo API (owner-only)

### DIFF
--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -36,8 +36,8 @@ Phase 1（issue #21 / #22）: 描いた絵に「振り返りメモ」を紐づ�
 - [x] U2 自動タグ＋埋め込み（#29/#30/#31 マージ済・実機検証済）
 - [x] U3a タグ絞り込み（#32 マージ済・Pages デプロイ成功 2026-06-28）
 - [x] U3b 意味検索（#34 マージ・apply・実機検証済 2026-06-28）
-- [ ] U4 メモ編集＋非公開API（未着手・ADR-003 で authorizer 再利用裁定済）
-- [~] バックフィル（2026-06-28 実行）: 469枚 embedding / 464枚 tagged を本番反映（metadata.json 518件中タグ付き464、embeddings.json 469件）。**残49枚は enrich の重複タグバグで失敗**＝fix/enrich-dedup-tags で修正、apply 後に再実行で回収。
+- [~] U4 メモ編集＋非公開API（PR #36・ADR-003 で authorizer 再利用）。memos Lambda＋GET/PUT /memos/{key}（Basic認証）＋管理モードのメモ編集UI（公開/非公開トグル・デフォルト非公開）。保存後 update-images を非同期invokeして公開射影更新。terraform plan / lint / build 通過。apply はオーナー
+- [~] バックフィル（2026-06-28 実行）: 469枚 embedding / 464枚 tagged を本番反映（metadata.json 518件中タグ付き464、embeddings.json 469件）。**残49枚は enrich の重複タグバグで失敗**＝#35 で修正（マージ済）、apply 後に再実行で回収。
 
 ## U2 設計メモ（2026-06-27 オーナー承認: A案=非同期）
 - 生成タイミング: upload Lambda が S3保存+基本レコード作成の後に **enrich Lambda を Event invoke**（fire-and-forget）。S3 ObjectCreated は update-images が同条件で使用中=2本目トリガ不可のため、トリガ機構のみS3でなく直接async invoke（承認済み性質: 即返し/疎結合/障害隔離/バックフィル再利用は維持）。

--- a/terraform/lambda-functions/memos/index.js
+++ b/terraform/lambda-functions/memos/index.js
@@ -1,0 +1,97 @@
+// U4: 振り返りメモの取得/更新 API。オーナー限定（既存 Basic 認証 authorizer 再利用=ADR-003）。
+//  - GET  /memos/{key} : 1画像の memo と visibility を返す（非公開メモも認証済みなので返す）。
+//  - PUT  /memos/{key} : memo 本文と visibility(public|private) を保存。
+// 保存後は update-images を非同期invoke して公開射影 metadata.json を更新する
+// （metadata.json は visibility=public のメモだけを載せる。非公開メモは CDN に出ない=NFR-2）。
+const { DynamoDBClient, GetItemCommand, UpdateItemCommand } = require('@aws-sdk/client-dynamodb');
+const { LambdaClient, InvokeCommand } = require('@aws-sdk/client-lambda');
+
+const ddb = new DynamoDBClient({ region: process.env.AWS_DEFAULT_REGION });
+const lambda = new LambdaClient({ region: process.env.AWS_DEFAULT_REGION });
+
+// 管理画面(GitHub Pages)からのブラウザ呼び出しに応える CORS ヘッダ。
+const corsHeaders = {
+  'Access-Control-Allow-Origin': process.env.ALLOWED_ORIGIN,
+  'Access-Control-Allow-Methods': 'GET,PUT,OPTIONS',
+  'Access-Control-Allow-Headers': 'Authorization,Content-Type',
+};
+
+const MAX_MEMO_CHARS = 2000;
+
+const respond = (statusCode, payload) => ({
+  statusCode,
+  headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  body: JSON.stringify(payload),
+});
+
+exports.handler = async (event) => {
+  const method = event.httpMethod;
+  if (method === 'OPTIONS') return respond(200, {});
+
+  const rawKey = event.pathParameters && event.pathParameters.key;
+  const key = rawKey ? decodeURIComponent(rawKey) : '';
+  // 安全策: ルート直下の画像(.png)のみ対象。viewer/配下やフォルダは対象外。
+  if (!key || key.includes('/') || !key.endsWith('.png')) {
+    return respond(400, { error: 'Invalid image key' });
+  }
+
+  try {
+    if (method === 'GET') {
+      const res = await ddb.send(new GetItemCommand({
+        TableName: process.env.METADATA_TABLE,
+        Key: { imageId: { S: key } },
+        ProjectionExpression: 'imageId, memo, visibility',
+      }));
+      const it = res.Item || {};
+      return respond(200, {
+        imageId: key,
+        memo: (it.memo && it.memo.S) || '',
+        visibility: (it.visibility && it.visibility.S) || 'private',
+      });
+    }
+
+    if (method === 'PUT') {
+      let parsed;
+      try {
+        parsed = event.body ? JSON.parse(event.body) : {};
+      } catch (e) {
+        return respond(400, { error: 'Invalid JSON body' });
+      }
+      const memo = typeof parsed.memo === 'string' ? parsed.memo : '';
+      if (memo.length > MAX_MEMO_CHARS) {
+        return respond(400, { error: `memo too long (max ${MAX_MEMO_CHARS} chars)` });
+      }
+      // visibility は public|private のみ許可。不正値は private に倒す（デフォルト非公開=既決事項）。
+      const visibility = parsed.visibility === 'public' ? 'public' : 'private';
+
+      await ddb.send(new UpdateItemCommand({
+        TableName: process.env.METADATA_TABLE,
+        Key: { imageId: { S: key } },
+        UpdateExpression: 'SET #m = :m, #v = :v',
+        ExpressionAttributeNames: { '#m': 'memo', '#v': 'visibility' },
+        ExpressionAttributeValues: { ':m': { S: memo }, ':v': { S: visibility } },
+      }));
+
+      // 公開射影 metadata.json を更新するため update-images を非同期invoke(fire-and-forget)。
+      // 失敗してもメモ保存自体は成功扱い(次のアップロードや手動invokeでも再生成される)。
+      if (process.env.UPDATE_IMAGES_FUNCTION) {
+        try {
+          await lambda.send(new InvokeCommand({
+            FunctionName: process.env.UPDATE_IMAGES_FUNCTION,
+            InvocationType: 'Event',
+            Payload: Buffer.from(JSON.stringify({ reason: 'memo-updated', imageId: key })),
+          }));
+        } catch (e) {
+          console.error('update-images invoke failed (memo は保存済み):', e);
+        }
+      }
+
+      return respond(200, { imageId: key, memo, visibility });
+    }
+
+    return respond(405, { error: 'Method not allowed' });
+  } catch (error) {
+    console.error('memos handler error:', error);
+    return respond(500, { error: 'Internal error' });
+  }
+};

--- a/terraform/lambda-functions/memos/package-lock.json
+++ b/terraform/lambda-functions/memos/package-lock.json
@@ -1,0 +1,581 @@
+{
+  "name": "memos",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "memos",
+      "version": "1.0.0",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.700.0",
+        "@aws-sdk/client-lambda": "^3.700.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1075.0.tgz",
+      "integrity": "sha512-3KlTXh6U2nDqL+epT1XdxnszLtCEAvoeO7phI4UGiQeKMiibcyBsJvSlyEj1tBoNOsbdcmp1QLM8za415sDzzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-node": "^3.972.58",
+        "@aws-sdk/dynamodb-codec": "^3.973.23",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.19",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1075.0.tgz",
+      "integrity": "sha512-S+sy0L7WEouGGys0kJZJ+br0sQGxgWC+0nR/4ySsym/CSg/k+VHXBdD697WJLli+X5a76tFBshx5bjgVKgLg4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-node": "^3.972.58",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+      "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.31",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
+      "integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
+      "integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.56",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
+      "integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-login": "^3.972.55",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
+      "integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
+      "integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-ini": "^3.972.56",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
+      "integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
+      "integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/token-providers": "3.1074.0",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
+      "integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.23.tgz",
+      "integrity": "sha512-GFfrjNXw+QteWbum8jD22G3T0FD/XiJEGp6r1CoqndMc6pxyQFoQ8nqTuNn1rbqYwqv4iCTl7GYoB9H17REKzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.8.tgz",
+      "integrity": "sha512-bBmkG0Dnhfq0/T4Z0PpUr7HkncBVaWvvCbvafeaUM+yC9wa8GGjLJmonq0QL17REB9WivgGeYgWQ5A80Uw5UnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.19.tgz",
+      "integrity": "sha512-FMgyzUq3Jh+ONRYxryBRNdBd+FUX8PwRl07ccQknNdoms6KCeAEusCkl6whqpDrPQ6OH0ddeSifKyqYSs2DLIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.8",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
+      "integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1074.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
+      "integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+      "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+      "integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
+      "integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
+      "integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+      "integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+      "integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    }
+  }
+}

--- a/terraform/lambda-functions/memos/package.json
+++ b/terraform/lambda-functions/memos/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "memos",
+  "version": "1.0.0",
+  "description": "U4: get/put reflection memo + visibility for an image (owner-only, reuses Basic-auth authorizer)",
+  "private": true,
+  "main": "index.js",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.700.0",
+    "@aws-sdk/client-lambda": "^3.700.0"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -650,6 +650,14 @@ resource "aws_api_gateway_deployment" "main" {
       aws_api_gateway_integration.search.id,
       aws_api_gateway_method.search_options.id,
       aws_api_gateway_integration.search_options.id,
+      aws_api_gateway_resource.memos.id,
+      aws_api_gateway_resource.memo_key.id,
+      aws_api_gateway_method.memo_get.id,
+      aws_api_gateway_integration.memo_get.id,
+      aws_api_gateway_method.memo_put.id,
+      aws_api_gateway_integration.memo_put.id,
+      aws_api_gateway_method.memo_options.id,
+      aws_api_gateway_integration.memo_options.id,
       var.admin_allowed_origin, # originを変えたらプリフライト応答を再デプロイさせる
     ]))
   }
@@ -1066,6 +1074,207 @@ resource "aws_lambda_permission" "api_gateway_invoke_search" {
   statement_id  = "AllowExecutionFromAPIGateway"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.query_embed.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.main.execution_arn}/*/*/*"
+}
+
+# =====================================================================================
+# U4 MEMO EDIT: memos Lambda + GET/PUT /memos/{key} (Basic認証) + CORS preflight
+# 振り返りメモの取得/更新。オーナー限定(既存 authorizer 再利用=ADR-003)。保存後に
+# update-images を非同期invoke して公開射影 metadata.json を更新する(公開メモのみ載る)。
+# =====================================================================================
+
+resource "terraform_data" "memos_deps" {
+  triggers_replace = [
+    filesha256("${path.module}/lambda-functions/memos/index.js"),
+    filesha256("${path.module}/lambda-functions/memos/package.json"),
+    filesha256("${path.module}/lambda-functions/memos/package-lock.json"),
+  ]
+  provisioner "local-exec" {
+    working_dir = "${path.module}/lambda-functions/memos"
+    command     = "npm ci --omit=dev --no-audit --no-fund || npm install --omit=dev --no-audit --no-fund"
+  }
+}
+
+data "archive_file" "memos_lambda" {
+  depends_on  = [terraform_data.memos_deps] # node_modules を含めるため install 後に zip
+  type        = "zip"
+  output_path = "lambda_memos.zip"
+  source_dir  = "lambda-functions/memos"
+}
+
+resource "aws_iam_role" "memos_lambda_execution" {
+  name = "${var.stack_name}-MemosLambdaExecutionRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "lambda.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  inline_policy {
+    name = "${var.stack_name}MemosPolicy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect   = "Allow"
+          Action   = ["dynamodb:GetItem", "dynamodb:UpdateItem"]
+          Resource = aws_dynamodb_table.image_metadata.arn
+        },
+        {
+          # 保存後の公開射影更新のため update-images を非同期invoke する。
+          Effect   = "Allow"
+          Action   = ["lambda:InvokeFunction"]
+          Resource = aws_lambda_function.update_images_json.arn
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+          Resource = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.stack_name}-MemosFunction:*"
+        }
+      ]
+    })
+  }
+
+  tags = var.stack_tags
+}
+
+resource "aws_lambda_function" "memos" {
+  function_name = "${var.stack_name}-MemosFunction"
+  handler       = "index.handler"
+  role          = aws_iam_role.memos_lambda_execution.arn
+  runtime       = "nodejs22.x"
+  timeout       = 10
+
+  filename         = data.archive_file.memos_lambda.output_path
+  source_code_hash = data.archive_file.memos_lambda.output_base64sha256
+
+  environment {
+    variables = {
+      METADATA_TABLE          = aws_dynamodb_table.image_metadata.name
+      ALLOWED_ORIGIN          = var.admin_allowed_origin
+      UPDATE_IMAGES_FUNCTION  = aws_lambda_function.update_images_json.function_name
+    }
+  }
+
+  tags = var.stack_tags
+}
+
+# /memos
+resource "aws_api_gateway_resource" "memos" {
+  parent_id   = aws_api_gateway_rest_api.main.root_resource_id
+  path_part   = "memos"
+  rest_api_id = aws_api_gateway_rest_api.main.id
+}
+
+# /memos/{key}
+resource "aws_api_gateway_resource" "memo_key" {
+  parent_id   = aws_api_gateway_resource.memos.id
+  path_part   = "{key}"
+  rest_api_id = aws_api_gateway_rest_api.main.id
+}
+
+# GET /memos/{key} （Basic認証=既存authorizer再利用。非公開メモも認証済みなら返す）
+resource "aws_api_gateway_method" "memo_get" {
+  http_method   = "GET"
+  resource_id   = aws_api_gateway_resource.memo_key.id
+  rest_api_id   = aws_api_gateway_rest_api.main.id
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.basic_auth.id
+
+  request_parameters = {
+    "method.request.path.key" = true
+  }
+}
+
+resource "aws_api_gateway_integration" "memo_get" {
+  http_method             = aws_api_gateway_method.memo_get.http_method
+  resource_id             = aws_api_gateway_resource.memo_key.id
+  rest_api_id             = aws_api_gateway_rest_api.main.id
+  type                    = "AWS_PROXY"
+  integration_http_method = "POST"
+  uri                     = "arn:aws:apigateway:${data.aws_region.current.name}:lambda:path/2015-03-31/functions/${aws_lambda_function.memos.arn}/invocations"
+}
+
+# PUT /memos/{key}
+resource "aws_api_gateway_method" "memo_put" {
+  http_method   = "PUT"
+  resource_id   = aws_api_gateway_resource.memo_key.id
+  rest_api_id   = aws_api_gateway_rest_api.main.id
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.basic_auth.id
+
+  request_parameters = {
+    "method.request.path.key" = true
+  }
+}
+
+resource "aws_api_gateway_integration" "memo_put" {
+  http_method             = aws_api_gateway_method.memo_put.http_method
+  resource_id             = aws_api_gateway_resource.memo_key.id
+  rest_api_id             = aws_api_gateway_rest_api.main.id
+  type                    = "AWS_PROXY"
+  integration_http_method = "POST"
+  uri                     = "arn:aws:apigateway:${data.aws_region.current.name}:lambda:path/2015-03-31/functions/${aws_lambda_function.memos.arn}/invocations"
+}
+
+# OPTIONS /memos/{key} （ブラウザのCORSプリフライト。認証不要のMOCK応答）
+resource "aws_api_gateway_method" "memo_options" {
+  http_method   = "OPTIONS"
+  resource_id   = aws_api_gateway_resource.memo_key.id
+  rest_api_id   = aws_api_gateway_rest_api.main.id
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "memo_options" {
+  http_method = aws_api_gateway_method.memo_options.http_method
+  resource_id = aws_api_gateway_resource.memo_key.id
+  rest_api_id = aws_api_gateway_rest_api.main.id
+  type        = "MOCK"
+
+  request_templates = {
+    "application/json" = "{\"statusCode\": 200}"
+  }
+}
+
+resource "aws_api_gateway_method_response" "memo_options" {
+  rest_api_id = aws_api_gateway_rest_api.main.id
+  resource_id = aws_api_gateway_resource.memo_key.id
+  http_method = aws_api_gateway_method.memo_options.http_method
+  status_code = "200"
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true
+    "method.response.header.Access-Control-Allow-Methods" = true
+    "method.response.header.Access-Control-Allow-Origin"  = true
+  }
+}
+
+resource "aws_api_gateway_integration_response" "memo_options" {
+  rest_api_id = aws_api_gateway_rest_api.main.id
+  resource_id = aws_api_gateway_resource.memo_key.id
+  http_method = aws_api_gateway_method.memo_options.http_method
+  status_code = aws_api_gateway_method_response.memo_options.status_code
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = "'Authorization,Content-Type'"
+    "method.response.header.Access-Control-Allow-Methods" = "'GET,PUT,OPTIONS'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.admin_allowed_origin}'"
+  }
+
+  depends_on = [aws_api_gateway_integration.memo_options]
+}
+
+resource "aws_lambda_permission" "api_gateway_invoke_memos" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.memos.function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.main.execution_arn}/*/*/*"
 }

--- a/viewer-react/src/components/ImageGallery.jsx
+++ b/viewer-react/src/components/ImageGallery.jsx
@@ -26,6 +26,8 @@ const ImageGallery = () => {
   const [searchError, setSearchError] = useState(null);
   // 画像側ベクトル(embeddings.json)は重いので検索時に一度だけ遅延ロードしてメモリにキャッシュ。
   const [embeddingsCache, setEmbeddingsCache] = useState(null);
+  // U4 メモ編集（オーナー限定）: 編集対象1枚のメモ本文と公開フラグを保持する小エディタの状態。
+  const [memoEditor, setMemoEditor] = useState(null); // null=閉/{imageId,memo,visibility,loading,saving,error}
 
   // 設定
   const BASE_URL = "https://d3a21s3joww9j4.cloudfront.net/";
@@ -213,6 +215,52 @@ const ImageGallery = () => {
     setSearchError(null);
   };
 
+  // U4: メモ編集を開く。GET /memos/{key}（Basic認証）で現在のメモ＋公開フラグを読み込む。
+  const openMemoEditor = async (imageName) => {
+    if (!admin) return;
+    setMemoEditor({ imageId: imageName, memo: '', visibility: 'private', loading: true, saving: false, error: null });
+    try {
+      const res = await fetch(`${API_BASE}/memos/${encodeURIComponent(imageName)}`, {
+        headers: { 'Authorization': 'Basic ' + btoa(`${admin.username}:${admin.password}`) },
+      });
+      if (res.status === 401 || res.status === 403) {
+        setMemoEditor(m => m && { ...m, loading: false, error: '認証に失敗しました。' });
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setMemoEditor(m => m && { ...m, memo: data.memo || '', visibility: data.visibility || 'private', loading: false });
+    } catch (err) {
+      console.error('メモ取得失敗', err);
+      setMemoEditor(m => m && { ...m, loading: false, error: `読み込み失敗: ${err.message}` });
+    }
+  };
+
+  // U4: メモ保存。PUT /memos/{key} で memo と visibility を更新。成功で閉じる。
+  const saveMemo = async () => {
+    if (!admin || !memoEditor) return;
+    setMemoEditor(m => ({ ...m, saving: true, error: null }));
+    try {
+      const res = await fetch(`${API_BASE}/memos/${encodeURIComponent(memoEditor.imageId)}`, {
+        method: 'PUT',
+        headers: {
+          'Authorization': 'Basic ' + btoa(`${admin.username}:${admin.password}`),
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ memo: memoEditor.memo, visibility: memoEditor.visibility }),
+      });
+      if (res.status === 401 || res.status === 403) {
+        setMemoEditor(m => m && { ...m, saving: false, error: '認証に失敗しました。' });
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setMemoEditor(null); // 成功 → 閉じる
+    } catch (err) {
+      console.error('メモ保存失敗', err);
+      setMemoEditor(m => m && { ...m, saving: false, error: `保存失敗: ${err.message}` });
+    }
+  };
+
   if (loading) {
     return <div>Loading...</div>;
   }
@@ -374,6 +422,7 @@ const ImageGallery = () => {
             onImageClick={handleImageClick}
             adminMode={!!admin}
             onDelete={handleDelete}
+            onMemoEdit={openMemoEditor}
           />
         ))}
       </Masonry>
@@ -392,6 +441,50 @@ const ImageGallery = () => {
         imageUrl={modalImageUrl}
         onClose={handleModalClose}
       />
+
+      {/* U4 メモ編集（オーナー限定）: 中央のモーダルでメモ本文＋公開/非公開トグルを編集 */}
+      {memoEditor && (
+        <div
+          onClick={() => !memoEditor.saving && setMemoEditor(null)}
+          style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100 }}
+        >
+          <div
+            onClick={e => e.stopPropagation()}
+            style={{ background: '#fff', borderRadius: 8, padding: 20, width: 'min(520px, 92vw)', boxShadow: '0 8px 30px rgba(0,0,0,0.3)' }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+              <strong>メモ編集</strong>
+              <span style={{ fontSize: '0.75rem', color: '#888' }}>{memoEditor.imageId}</span>
+            </div>
+            <div style={{ display: 'flex', gap: 10, marginBottom: 10 }}>
+              <img src={BASE_URL + memoEditor.imageId} alt="" style={{ width: 96, height: 96, objectFit: 'contain', background: '#f5f5f5', borderRadius: 4 }} />
+              <textarea
+                placeholder={memoEditor.loading ? '読み込み中…' : '振り返りメモ（自由記述）'}
+                value={memoEditor.memo}
+                disabled={memoEditor.loading || memoEditor.saving}
+                onChange={e => setMemoEditor(m => ({ ...m, memo: e.target.value }))}
+                style={{ flex: 1, minHeight: 110, padding: 8, border: '1px solid #ccc', borderRadius: 4, resize: 'vertical', fontFamily: 'inherit' }}
+              />
+            </div>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 12, fontSize: '0.9rem' }}>
+              <input
+                type="checkbox"
+                checked={memoEditor.visibility === 'public'}
+                disabled={memoEditor.loading || memoEditor.saving}
+                onChange={e => setMemoEditor(m => ({ ...m, visibility: e.target.checked ? 'public' : 'private' }))}
+              />
+              このメモを公開する（オフ＝非公開・自分だけ。デフォルト非公開）
+            </label>
+            {memoEditor.error && <div style={{ color: '#c0392b', fontSize: '0.85rem', marginBottom: 8 }}>{memoEditor.error}</div>}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+              <button style={adminBtnStyle} onClick={() => setMemoEditor(null)} disabled={memoEditor.saving}>キャンセル</button>
+              <button style={adminBtnStyle} onClick={saveMemo} disabled={memoEditor.loading || memoEditor.saving}>
+                {memoEditor.saving ? '保存中…' : '保存'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 };

--- a/viewer-react/src/components/ImageItem.jsx
+++ b/viewer-react/src/components/ImageItem.jsx
@@ -1,4 +1,4 @@
-const ImageItem = ({ imageName, baseUrl, onImageClick, adminMode, onDelete }) => {
+const ImageItem = ({ imageName, baseUrl, onImageClick, adminMode, onDelete, onMemoEdit }) => {
   const extractTimestamp = (name) => {
     const m = name.match(/(\d{10,13})(?=\.[A-Za-z]+$)/);
     if (!m) return null;
@@ -41,6 +41,11 @@ const ImageItem = ({ imageName, baseUrl, onImageClick, adminMode, onDelete }) =>
     onDelete(imageName);
   };
 
+  const handleMemoClick = (e) => {
+    e.stopPropagation();
+    onMemoEdit(imageName);
+  };
+
   const getImageUrl = () => {
     return baseUrl + imageName;  // 常にCloudFrontの実際の画像を使用
   };
@@ -63,6 +68,16 @@ const ImageItem = ({ imageName, baseUrl, onImageClick, adminMode, onDelete }) =>
           style={{ position: 'absolute', top: 4, left: 4, background: '#c0392b', color: '#fff', zIndex: 2, opacity: 1, visibility: 'visible' }}
         >
           削除
+        </button>
+      )}
+
+      {adminMode && (
+        <button
+          className="ctrl-btn memo-btn"
+          onClick={handleMemoClick}
+          style={{ position: 'absolute', top: 4, left: 54, background: '#2c3e50', color: '#fff', zIndex: 2, opacity: 1, visibility: 'visible' }}
+        >
+          メモ
         </button>
       )}
 


### PR DESCRIPTION
## 概要
U4「振り返りメモ編集＋非公開API」を実装。管理モードで各画像にメモを書き、公開/非公開を切り替えられる（ADR-003: 既存 Basic 認証 authorizer 再利用・**デフォルト非公開**）。

## バックエンド
- **memos Lambda**（新規）:
  - `GET /memos/{key}` → memo＋visibility を返す（認証済みなので**非公開メモも返す**）。
  - `PUT /memos/{key}` → memo本文＋visibility(public|private) を保存し、**update-images を非同期invoke**して公開射影 metadata.json を更新。
- ルートは既存 authorizer 配下＋CORSプリフライト。最小権限IAM（DDB Get/UpdateItem＋update-images invoke＋スコープ済logs）。依存は #30 流儀で決定的バンドル。
- **プライバシー（NFR-2）**: metadata.json は `visibility=public` のメモだけを載せる（既存 update-images の射影ロジック）。非公開メモは CDN に出ない。

## フロント
- 管理モードで画像ごとに **「メモ」ボタン** → モーダルエディタ（GET で現在のメモ読込→textarea＋公開/非公開チェック→PUT保存）。デフォルト非公開。

## 検証
- `terraform validate` + `plan` クリーン（**15 add / 2 change / 1 replace**＝API再デプロイ）。frontend **lint 0 errors** / **vite build 成功**。
- ※plan の in-place `aws_s3_bucket_policy` は本PR由来でない既存ドリフト。

## オーナー作業
- **`terraform apply`**（memos Lambda＋/memos ルート本番化）。apply 後、管理モードで任意画像の「メモ」→保存→公開トグルを実機確認可能。

未マージの関連PR: #35（enrich重複タグ修正・要apply）。