### PR TITLE
fix(viewer): stop viewer/ json files showing as broken gallery tiles

### DIFF
--- a/terraform/lambda-functions/update-images/index.js
+++ b/terraform/lambda-functions/update-images/index.js
@@ -19,6 +19,9 @@ exports.handler = async (event) => {
         ContinuationToken: continuationToken,
       }));
       for (const object of listObjectsResponse.Contents || []) {
+        // viewer/ 配下は運用ファイル(images.json / metadata.json / embeddings.json / index.html 等)で
+        // 作品画像ではない。images.json には載せない(フロントでもう一段はじくが、源泉から綺麗にしておく)。
+        if (object.Key.startsWith('viewer/')) continue;
         fileNames.push(object.Key);
       }
       continuationToken = listObjectsResponse.IsTruncated

--- a/viewer-react/src/components/ImageGallery.jsx
+++ b/viewer-react/src/components/ImageGallery.jsx
@@ -33,7 +33,9 @@ const ImageGallery = () => {
   const META_URL = "https://d3a21s3joww9j4.cloudfront.net/viewer/metadata.json";
   const EMBED_URL = "https://d3a21s3joww9j4.cloudfront.net/viewer/embeddings.json";
   const API_BASE = "https://3p4utkstnb.execute-api.ap-northeast-1.amazonaws.com/prod";
-  const EXCLUDE = ["viewer/", "viewer/index.html", "viewer/images.json"];
+  // viewer/ 配下は運用ファイル(images.json / metadata.json / embeddings.json / index.html 等)であって
+  // 作品画像ではない。接頭辞で一括除外する（完全一致だと新しい viewer/ 成果物が漏れてタイル表示されてしまう）。
+  const EXCLUDE_PREFIX = "viewer/";
   const INITIAL_COUNT = 20;
   const SEARCH_RESULT_LIMIT = 60; // 意味検索の上位表示件数
 
@@ -62,7 +64,7 @@ const ImageGallery = () => {
 
       // フィルタリングとソート
       const filteredFiles = files
-        .filter(name => !EXCLUDE.includes(name))
+        .filter(name => typeof name === 'string' && !name.startsWith(EXCLUDE_PREFIX))
         .sort((a, b) => b.localeCompare(a)); // 降順（新しい順）
 
       // metadata.json から imageId -> autoTags を構築（取得できた場合のみ）


### PR DESCRIPTION
## バグ
ギャラリーに `viewer/metadata.json` と `viewer/embeddings.json` が**壊れた画像タイル**として表示されていた（スクショ報告）。

## 原因
`images.json` はバケット全体を列挙するので `viewer/` 配下の運用ファイルも含む。フロントの除外が**完全一致**（`["viewer/", "viewer/index.html", "viewer/images.json"]`）で、`viewer/metadata.json`・`viewer/embeddings.json`（U1/U3b で追加）を素通ししていた。

## 修正
- **フロント**: `viewer/` **接頭辞**で一括除外（完全一致をやめる）。今後 `viewer/` 配下に何を足しても漏れない。→ **main マージ＝Pages デプロイで即反映**。
- **バックエンド**: update-images が `images.json` 生成時に `viewer/` キーを除外。源泉も綺麗に。→ 次の apply で反映。

lint 0 errors / build 成功。

**これをマージすれば（Pages 自動デプロイ）壊れたタイルは消えます。** apply は不要（バックエンド分は次の apply のついでで可）。