### PR TITLE
fix(u2): detect real image format for Bedrock (JPEG saved as .png)

### DIFF
--- a/terraform/lambda-functions/image-enrich/index.js
+++ b/terraform/lambda-functions/image-enrich/index.js
@@ -29,11 +29,28 @@ async function getImageBytes(bucket, key) {
 }
 
 /**
+ * 実バイトのマジックナンバーから画像形式を判定する。
+ * 既存画像には拡張子が .png でも中身が JPEG 等のものが混ざっており、Bedrock は
+ * 申告した format と実体の不一致を ValidationException で弾く(= 埋め込み/タグ両方失敗)。
+ * よって拡張子ではなく実バイトで判定し、正しい format を Bedrock に渡す。
+ * Nova(埋め込み/Lite) は png/jpeg/gif/webp を受け付ける。判定不能は png にフォールバック。
+ * @param {Buffer} buf 画像バイト列
+ * @returns {'png'|'jpeg'|'gif'|'webp'} 画像形式
+ */
+function detectImageFormat(buf) {
+  if (buf.length >= 4 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'png';
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'jpeg';
+  if (buf.length >= 3 && buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46) return 'gif';
+  if (buf.length >= 12 && buf.toString('ascii', 0, 4) === 'RIFF' && buf.toString('ascii', 8, 12) === 'WEBP') return 'webp';
+  return 'png';
+}
+
+/**
  * Nova マルチモーダル埋め込みで画像をベクトル化する(検索インデックス用)。
  * @param {string} b64 base64エンコード済み画像
  * @returns {Promise<number[]>} 埋め込みベクトル
  */
-async function embedImage(b64) {
+async function embedImage(b64, format) {
   const body = {
     schemaVersion: 'nova-multimodal-embed-v1',
     taskType: 'SINGLE_EMBEDDING',
@@ -41,7 +58,7 @@ async function embedImage(b64) {
       embeddingPurpose: 'GENERIC_INDEX', // インデックス作成用(検索クエリ側は IMAGE_RETRIEVAL を使う)
       embeddingDimension: Number(process.env.EMBEDDING_DIMENSION || '1024'),
       image: {
-        format: 'png',
+        format, // 実バイトから判定した形式(png/jpeg/gif/webp)。拡張子は当てにしない。
         detailLevel: 'STANDARD_IMAGE',
         source: { bytes: b64 }, // 25MB(base64後)以内のインライン。本アプリのupload上限は10MB。
       },
@@ -70,7 +87,7 @@ async function embedImage(b64) {
  * @param {string} b64 base64エンコード済み画像
  * @returns {Promise<string[]>} 日本語タグ配列(最大 MAX_TAGS 件)
  */
-async function generateTags(b64) {
+async function generateTags(b64, format) {
   const modelId = process.env.TAG_MODEL_ID;
   const prompt = 'この画像はユーザーが描いた絵です。後で検索で見つけやすくするための日本語タグを付けてください。'
     + `描かれているもの(被写体・モチーフ・場面)、画風や画材、色合い、雰囲気など、その絵を表す語を${MAX_TAGS}個以内で自由に。`
@@ -85,7 +102,7 @@ async function generateTags(b64) {
           {
             role: 'user',
             content: [
-              { image: { format: 'png', source: { bytes: b64 } } },
+              { image: { format, source: { bytes: b64 } } },
               { text: prompt },
             ],
           },
@@ -99,7 +116,7 @@ async function generateTags(b64) {
           {
             role: 'user',
             content: [
-              { type: 'image', source: { type: 'base64', media_type: 'image/png', data: b64 } },
+              { type: 'image', source: { type: 'base64', media_type: `image/${format}`, data: b64 } },
               { type: 'text', text: prompt },
             ],
           },
@@ -148,9 +165,11 @@ exports.handler = async (event) => {
 
   const bytes = await getImageBytes(process.env.IMAGE_BUCKET, imageId);
   const b64 = bytes.toString('base64');
+  // 拡張子が .png でも中身が JPEG 等のことがあるので実バイトで形式判定して Bedrock に渡す。
+  const format = detectImageFormat(bytes);
 
   // 埋め込みとタグは独立なので並列化(片方失敗でも他方は活かす)。
-  const [embedResult, tagResult] = await Promise.allSettled([embedImage(b64), generateTags(b64)]);
+  const [embedResult, tagResult] = await Promise.allSettled([embedImage(b64, format), generateTags(b64, format)]);
 
   const exprNames = {};
   const exprValues = {};


### PR DESCRIPTION
## バグ
バックフィルの残43枚は**中身がJPEGなのに `.png` 拡張子**の画像。enrich が Bedrock に `format:'png'`／`media_type:'image/png'` 固定で渡すため、実体(JPEG)と不一致で `ValidationException` → **埋め込み・タグ両方失敗**し検索母集団に入れなかった。

CloudWatch 実エラー:
```
embedImage failed: ValidationException: The detected file MIME type image/jpeg
does not match the expected type image/png.
```

## 修正（1ファイル）
`terraform/lambda-functions/image-enrich/index.js`:
- `detectImageFormat(buf)` 追加: 先頭バイトで png/jpeg/gif/webp を判定（不明は png フォールバック）。
- `embedImage`/`generateTags` を `(b64, format)` 化し、Nova 埋め込み・タグ両方に判定形式を渡す。

## 実機検証済（PR前に確認・憲法準拠）
残43枚の1枚 `1751547495073.png`（先頭 `ffd8ffe0`=JPEG）を **format='jpeg' で実 Invoke**:
- Nova 埋め込み → **1024次元 成功**
- Nova Lite タグ → 成功（`["スケッチ","人物","構図",…]`）

## 適用後の正規手順（オーナー）
1. merge → `terraform apply`（enrich 更新）
2. `#38`(backfill consistent-read) も merge → `CONCURRENCY=1 node scripts/backfill-enrich.mjs`
3. `update-images` invoke で公開JSON再生成
→ 43枚も埋め込み・タグ付与され、ほぼ全520枚が検索・タグ対象に。

注: 既存データは無事（S3に520枚全存在を確認・削除等は一切なし）。原因は enrich の format 決め打ち。