### PR TITLE
feat(scripts): register orphan JPG/JPEG images into metadata DB

### DIFF
--- a/aidlc-docs/HANDOVER.md
+++ b/aidlc-docs/HANDOVER.md
@@ -1,8 +1,9 @@
-# 引き継ぎ書 — sketch-stacker Phase 1（2026-06-27 時点）
+# 引き継ぎ書 — sketch-stacker Phase 1（2026-07-01 時点）
 
 ## 0. 一言サマリ
 描いた絵に「振り返りメモ＋自動タグ＋意味検索」を足す Phase 1。
-**Inception 完了 / Construction U1・U2 は本番反映＆実機検証済み / U3 着手中（U3a=タグ絞り込みは PR #32）/ U4 未着手。**
+**Phase 1 機能的に完了。U1〜U4 すべて本番反映＆実機検証済み。既存全600枚のバックフィル完了（601 DDBレコードが embedding 済・タグ付き594）＝ギャラリー全600枚がタグ絞り込み・意味検索の対象。**
+**残: PR #40（孤立画像登録スクリプト＋本ドキュメント）マージのみ / ADR-005（検索エンドポイント=オーナー限定）オーナー批准待ち。次フェーズは Phase 2＝リファレンス写真管理（未着手・要 Inception）。**
 
 ---
 
@@ -32,13 +33,19 @@
 3. **S3 ObjectCreated(.png)** → **update-images** → `images.json`（キー配列）＋ `viewer/metadata.json`（`imageId/uploadedAt/autoTags/memo`※memoは公開のみ）を生成し CloudFront invalidate。
 4. **フロント** → `images.json`＋`metadata.json` を取得し表示（U3aでタグ絞り込み）。
 
-## 4. 進捗（AI-DLC / Construction）
-- Inception 完了：requirements / ADR-001〜004 / 実行計画（`aidlc-docs/inception/`）
-- **U1 メタ基盤**（PR #28）反映済
-- **U2 自動タグ＋埋め込み**（#29）＋ 依存バンドル（#30）＋ タグモデル修正（#31）反映済・**実機検証済**
-  - 実証: 実画像 enrich→`embedded:true/tagged:true`、DDBに日本語タグ10個＋1024次元ベクトル、API upload→自動enrich連鎖も確認
-- **U3 検索**：U3a タグ絞り込み=**PR #32 オープン（未マージ）**。U3b 意味検索=**未着手**
-- **U4 メモ編集＋非公開API**：**未着手**
+## 4. 進捗（AI-DLC / Construction）— Phase 1 完了
+- Inception 完了：requirements / ADR-001〜005 / 実行計画（`aidlc-docs/inception/`）
+- **U1 メタ基盤**（#28）／**U2 自動タグ＋埋め込み**（#29/#30/#31）反映済・実機検証済
+- **U3a タグ絞り込み**（#32・フロント client-side・公開）反映済
+- **U3b 意味検索**（#34・query-embed Lambda＋`POST /search`＋`viewer/embeddings.json`射影＋ブラウザ内コサイン。**オーナー限定**=既存authorizer・ADR-005=A）反映済・実機検証済
+- **U4 メモ編集＋非公開API**（#36・memos Lambda＋`GET/PUT /memos/{key}`＋管理モードUI・デフォルト非公開）反映済・実機検証済
+- **バックフィル完了**：全601 DDBレコード embedding済（タグ付き594）。`embeddings.json`=601 / `metadata.json` タグ付き594 / `images.json`=600（viewer/混入0）。ギャラリー全600枚がタグ・検索対象。
+- **バックフィルで見つけて直した実バグ**（全て本番反映）:
+  - **#35** タグ重複→DDB String Set拒否でUpdateItem丸ごと失敗（埋め込みも巻き添え）→ Setで重複除去。
+  - **#37** `images.json`にviewer/運用ファイル混入→ギャラリーに壊れたタイル→ 接頭辞除外（フロント＋update-images）。
+  - **#39** 中身JPEGなのに.png拡張子→enrichが`format:'png'`決め打ち→Bedrock MIME不一致で両失敗→ マジックナンバーで実形式判定。
+  - **#38** backfillの対象スキャンが結果整合で収束せず→ `ConsistentRead`化。
+  - **#40（マージ待ち）** バケットにあってDDB未登録のJPG/JPEG 80枚を登録する `scripts/register-orphan-images.mjs`。登録→enrichで全600枚カバー達成。
 
 ## 5. 重要な決定・ハマりどころ（必読）
 - **ADR-004（タグモデル）= `amazon.nova-lite-v1:0`**。理由（**実機検証で判明**）：`anthropic.claude-3-haiku-20240307-v1:0` は **Legacy化で InvokeModel 不可**、Claude 3.5系は **EOL**、Claude 4.5系（`us.anthropic.claude-haiku-4-5-*` 等）は active だが **アカウントへの Anthropic 用途フォーム提出が必須**（オーナーのコンソール操作）。Nova Lite は用途フォーム不要・即動作・低コスト・画像入力対応。
@@ -51,17 +58,27 @@
 - **AWS SSOトークンは失効する**（数分〜数日）。AWS操作前に必ず `aws sso login --profile dev`。
 - **terraform state はローカル**（S3 backend 未設定）。消失・ロック無しに注意。
 
-## 6. 残作業（優先順）
-1. ~~**PR #32（U3aタグ絞り込み）レビュー→マージ**~~ → **完了**（2026-06-28 マージ済 `41c778f`・Pages デプロイ成功）。※ `metadata.json` にタグが載るのは **enrich済み画像のみ**＝バックフィル前はタグが少ない。
-2. **バックフィル（既存 518枚・未処理 516枚）**：`cd scripts && npm install`（初回のみ）→ `aws sso login --profile dev` → `AWS_PROFILE=dev REGION=ap-northeast-1 node scripts/backfill-enrich.mjs --limit 5`（試走）→ 全量。**一時費用 ≈ $10.5**（埋め込み≈$0.5＋タグ≈$10）。
-   - ⚠ **バックフィルは DDB を更新するだけ**。完了後に **update-images を1回手動invoke**して公開射影 `viewer/metadata.json` を再生成すること（下記）。これをしないとフロントにタグが出ない。
-     `aws lambda invoke --function-name WIPUploaderUpdateImagesJsonFunction --payload '{}' --cli-binary-format raw-in-base64-out --profile dev --region ap-northeast-1 /tmp/upd.json`
-   - ✅ **通し検証済（2026-06-28）**：1枚 enrich→DDB(autoTags10/embedding1024)→update-images→metadata.json(518件中タグ付き3件、対象画像にタグ反映) を実機確認。スクリプトは依存マニフェスト欠如で初回失敗→`scripts/package.json` 追加で修正済。
-   - 実数注記: ハンドオフ初版の「592枚」は概数。DDB 実数は **518件**（処理済2件＝U2検証分）。
-3. **U3b 意味検索**：(a) update-images に embedding 射影（**別ファイル `viewer/embeddings.json` 推奨**＝ギャラリー軽量化・検索時に遅延ロード）(b) **クエリ埋め込みLambda＋APIルート**（Nova text 埋め込み・`embeddingPurpose=IMAGE_RETRIEVAL`・dim1024）(c) フロント検索ボックス＋ブラウザ内コサイン。
-   - 設計判断（検索エンドポイントを**公開**にするか**オーナー限定(既存authorizer)**にするか＝コスト/悪用リスク）は **ADR-005 で裁定推奨**（憲法「断定しない」）。
-4. **U4 メモ編集＋非公開API**：`GET/PUT /memos`（Basic認証・既存authorizer再利用＝ADR-003）。管理UI（`?admin`）にメモ編集＋公開トグル。
-5. （任意）terraform state を S3 backend 化。残セキュリティ #14–20 は完了済み。
+## 6. 残作業
+Phase 1（U1〜U4＋バックフィル）は完了。残りは以下:
+1. **PR #40 マージ**（`scripts/register-orphan-images.mjs`＋本ドキュメント更新）。apply不要・スクリプトはローカル実行。
+2. **ADR-005 のオーナー批准**：意味検索 `POST /search` を**オーナー限定（案A・実装済）**のままにするか、公開（案B・要レート制限）にするか。公開化するなら method の authorizer を外す1行＋別ADRでレート制限。
+3. **（任意・軽微）** DDBゴーストレコード1件（S3に画像実体なし・過去削除分）。images.json に出ないので表示・検索影響なし。消すなら明示指示で。
+4. **（任意）** terraform state を S3 backend 化（現状ローカル・ロック無し）。
+5. **次フェーズ = Phase 2（リファレンス写真管理）**：未着手。issue #21 の構想。新機能なので Inception（要件ヒアリング）から。
+
+### バックフィル再実行が要るとき（新規追加画像や再処理）
+```
+cd scripts && npm install            # 初回のみ
+aws sso login --profile dev
+# バケットにあってDB未登録の画像を登録（JPG/JPEG等）
+AWS_PROFILE=dev REGION=ap-northeast-1 node scripts/register-orphan-images.mjs
+# 未embedding を enrich（JPEG対応・ConsistentReadで収束）
+AWS_PROFILE=dev REGION=ap-northeast-1 CONCURRENCY=1 node scripts/backfill-enrich.mjs
+# 公開射影を再生成（★これを忘れるとフロントに反映されない。enrich直後は結果整合ラグで
+#   件数が古く出ることがある＝少し待って もう一度叩けば正しい件数になる）
+aws lambda invoke --function-name WIPUploaderUpdateImagesJsonFunction --payload '{}' \
+  --cli-binary-format raw-in-base64-out --profile dev --region ap-northeast-1 /tmp/upd.json
+```
 
 ## 7. 役割分担
 - **オーナーのみ**：`terraform apply`、`aws sso login`、Anthropic用途フォーム提出、バックフィル実行（費用発生）、PRマージ。

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -2,9 +2,9 @@
 
 - Workflow: AI-DLC v1.0.0
 - Workspace: **Brownfield**（既存: React/Vite + Terraform + Lambda）
-- Phase: 🟢 CONSTRUCTION（U1/U2/U3a 完了・本番反映済）
-- Stage: **U3a マージ済（#32）→ 次は バックフィル（オーナー）/ U3b意味検索 or U4メモ**
-- Updated: 2026-06-28
+- Phase: 🟢 CONSTRUCTION **完了**（U1〜U4 本番反映・実機検証済）→ Phase 1 機能的に完了
+- Stage: **全Unit apply済＋バックフィル完了（全600枚がタグ・検索対象）。残: PR #40 マージのみ**
+- Updated: 2026-07-01
 
 ## Intent
 Phase 1（issue #21 / #22）: 描いた絵に「振り返りメモ」を紐づけ、**手動タグ無しでモチーフを意味検索**できるギャラリーへ拡張する。
@@ -36,8 +36,20 @@ Phase 1（issue #21 / #22）: 描いた絵に「振り返りメモ」を紐づ�
 - [x] U2 自動タグ＋埋め込み（#29/#30/#31 マージ済・実機検証済）
 - [x] U3a タグ絞り込み（#32 マージ済・Pages デプロイ成功 2026-06-28）
 - [x] U3b 意味検索（#34 マージ・apply・実機検証済 2026-06-28）
-- [~] U4 メモ編集＋非公開API（PR #36・ADR-003 で authorizer 再利用）。memos Lambda＋GET/PUT /memos/{key}（Basic認証）＋管理モードのメモ編集UI（公開/非公開トグル・デフォルト非公開）。保存後 update-images を非同期invokeして公開射影更新。terraform plan / lint / build 通過。apply はオーナー
-- [~] バックフィル（2026-06-28 実行）: 469枚 embedding / 464枚 tagged を本番反映（metadata.json 518件中タグ付き464、embeddings.json 469件）。**残49枚は enrich の重複タグバグで失敗**＝#35 で修正（マージ済）、apply 後に再実行で回収。
+- [x] U4 メモ編集＋非公開API（#36 マージ・apply・実機検証済）。memos Lambda＋GET/PUT /memos/{key}（Basic認証）＋管理モードのメモ編集UI（公開/非公開トグル・デフォルト非公開）。
+- [x] バックフィル完了（2026-06〜07）: **全601 DDBレコードが embedding 済（タグ付き594）、embeddings.json=601・images.json=600（viewer/混入0）**。ギャラリー全600枚がタグ・検索対象。
+
+## バックフィルで判明・修正した実バグ（すべて本番反映済）
+- **#35**: タグモデルが重複タグを返すと DynamoDB String Set が拒否 → UpdateItem 丸ごと失敗（埋め込みも巻き添え）。→ タグを Set で重複除去。
+- **#37**: `images.json` に viewer/ 運用ファイルが混入しギャラリーに壊れたタイル表示。→ フロント/バックエンド両方で viewer/ 接頭辞除外。
+- **#39**: 中身JPEGなのに .png 拡張子の画像で enrich が format:'png' 決め打ち → Bedrock MIME不一致で埋め込み/タグ両失敗。→ マジックナンバーで実形式判定（png/jpeg/gif/webp）。実Invoke検証済。
+- **#38**: backfill の対象スキャンが結果整合で収束しなかった → ConsistentRead 化＋embedded/tagged 別集計。
+- **#40（マージ待ち）**: バケットにあってDDB未登録だった JPG/JPEG 80枚を登録するスクリプト（`scripts/register-orphan-images.mjs`）。登録→enrich 済で全600枚カバー達成。
+
+## 既知の軽微な残（対応任意・未着手）
+- DDBに画像実体の無いゴーストレコードが1件（過去削除画像）。images.json に出ないので表示・検索影響なし。
+- ADR-005（意味検索エンドポイント）= オーナー限定（案A）で実装・**オーナー批准待ち**。
+- delete は S3 論理削除のみで DDBレコードが残る設計（既存仕様）。
 
 ## U2 設計メモ（2026-06-27 オーナー承認: A案=非同期）
 - 生成タイミング: upload Lambda が S3保存+基本レコード作成の後に **enrich Lambda を Event invoke**（fire-and-forget）。S3 ObjectCreated は update-images が同条件で使用中=2本目トリガ不可のため、トリガ機構のみS3でなく直接async invoke（承認済み性質: 即返し/疎結合/障害隔離/バックフィル再利用は維持）。

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.700.0",
-        "@aws-sdk/client-lambda": "^3.700.0"
+        "@aws-sdk/client-lambda": "^3.700.0",
+        "@aws-sdk/client-s3": "^3.700.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -24,6 +25,31 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -75,6 +101,25 @@
         "tslib": "^2.6.2"
       }
     },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.8.tgz",
+      "integrity": "sha512-v0U9S7gBIme3OTgt1LdbAF4RpvavCc+4GK1+1xqAcqtbrHsEhjQo6R45LKcjhs/+WrRJij1Y0Gztw7QPAIeUfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.1075.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1075.0.tgz",
@@ -108,6 +153,31 @@
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "^3.974.23",
         "@aws-sdk/credential-provider-node": "^3.972.58",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1075.0.tgz",
+      "integrity": "sha512-h1A6nIl1YX6Y45enGsTK7ef3ZrOnBiQJ1qF5R2K/nMWfsu6A9mc2Y5T66nxerABzyjjyyvign3MrzafnFoQKmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-node": "^3.972.58",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.33",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.54",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
         "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/fetch-http-handler": "^5.4.6",
@@ -321,6 +391,36 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.8",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.33.tgz",
+      "integrity": "sha512-qMgQSPemQq2/eW/e/0+SpY4kYR5L7dUgBiVdEc5bd+ztHNv07ZMYiI+sTiir3TgKndFfglSw/VFi7oZJ6bZ63g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.54.tgz",
+      "integrity": "sha512-GDfDQ0gwLFRKN9gWIKcmVrHJ3e7XagnY7N1LLzMVNgnOnuY7f/ALgmy3CuBjosWD95T/Z6e+gs1IeWmLPkyLKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
         "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.700.0",
-    "@aws-sdk/client-lambda": "^3.700.0"
+    "@aws-sdk/client-lambda": "^3.700.0",
+    "@aws-sdk/client-s3": "^3.700.0"
   }
 }

--- a/scripts/register-orphan-images.mjs
+++ b/scripts/register-orphan-images.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// バケットに存在するのに DynamoDB メタデータレコードが無い画像(=孤立画像)に、基本レコードを作る。
+// 背景: 本アプリは PNG 前提(upload は PNG のみ受理・S3トリガも .png のみ)のため、過去に入った
+//   JPG/JPEG 等はメタデータDBに登録されず、タグ・検索の対象外だった。ここで基本レコードを作れば、
+//   後続の scripts/backfill-enrich.mjs が拾って enrich(タグ+埋め込み)してくれる。
+//   ※ enrich は #39 で実バイトから形式判定するよう修正済み = JPEG でも埋め込み/タグが付く。
+//
+// このスクリプト自体は upload Lambda と同じ基本レコード({imageId, uploadedAt, visibility=private})を
+// 作るだけ。タグ/埋め込みは作らない(それは enrich の責務)。べき等(既存レコードは上書きしない)。
+//
+// 事前準備(初回のみ): cd scripts && npm install
+// 使い方(リポジトリ root から):
+//   aws sso login --profile dev
+//   AWS_PROFILE=dev REGION=ap-northeast-1 node scripts/register-orphan-images.mjs --dry-run  # 対象を見るだけ
+//   AWS_PROFILE=dev REGION=ap-northeast-1 node scripts/register-orphan-images.mjs            # 実登録
+// この後 scripts/backfill-enrich.mjs を回すと孤立画像も enrich される。
+//
+// 環境変数で上書き可: REGION / METADATA_TABLE / IMAGE_BUCKET
+import { S3Client, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import { DynamoDBClient, ScanCommand, PutItemCommand } from '@aws-sdk/client-dynamodb';
+
+const REGION = process.env.REGION || 'ap-northeast-1';
+const TABLE = process.env.METADATA_TABLE || 'WIPUploader-ImageMetadata';
+const BUCKET = process.env.IMAGE_BUCKET || 'wip-uploader-strage';
+const DRY_RUN = process.argv.slice(2).includes('--dry-run');
+
+const s3 = new S3Client({ region: REGION });
+const ddb = new DynamoDBClient({ region: REGION });
+
+const IMAGE_RE = /\.(png|jpe?g|gif|webp)$/i;
+
+/** バケット内の画像キー一覧(viewer/ 運用ファイルは除外)。 */
+async function listBucketImages() {
+  const keys = [];
+  let token;
+  do {
+    const res = await s3.send(new ListObjectsV2Command({ Bucket: BUCKET, ContinuationToken: token }));
+    for (const o of res.Contents || []) {
+      if (o.Key.startsWith('viewer/')) continue;
+      if (IMAGE_RE.test(o.Key)) keys.push(o.Key);
+    }
+    token = res.IsTruncated ? res.NextContinuationToken : undefined;
+  } while (token);
+  return keys;
+}
+
+/** 既存の imageId 集合(強整合スキャンで取りこぼし防止)。 */
+async function listExistingIds() {
+  const ids = new Set();
+  let lastKey;
+  do {
+    const res = await ddb.send(new ScanCommand({
+      TableName: TABLE, ProjectionExpression: 'imageId', ExclusiveStartKey: lastKey, ConsistentRead: true,
+    }));
+    for (const it of res.Items || []) ids.add(it.imageId.S);
+    lastKey = res.LastEvaluatedKey;
+  } while (lastKey);
+  return ids;
+}
+
+/** ファイル名先頭の数字をアップロード時刻(ミリ秒)として取り出す。取れなければ null。 */
+function uploadedAtFromKey(key) {
+  const m = key.match(/(\d{10,13})/);
+  return m ? Number(m[1]) : null;
+}
+
+async function main() {
+  const [images, existing] = await Promise.all([listBucketImages(), listExistingIds()]);
+  const orphans = images.filter((k) => !existing.has(k));
+  console.log(`バケット画像 ${images.length} / DB登録済 ${existing.size} / 孤立(未登録) ${orphans.length}`);
+  if (DRY_RUN) {
+    console.log('--dry-run: 登録は行わない。対象先頭20件:');
+    orphans.slice(0, 20).forEach((k) => console.log('  ' + k));
+    return;
+  }
+
+  let created = 0, skipped = 0;
+  for (const key of orphans) {
+    const item = { imageId: { S: key }, visibility: { S: 'private' } };
+    const ts = uploadedAtFromKey(key);
+    if (ts != null) item.uploadedAt = { N: String(ts) };
+    try {
+      // 念のため条件付き(既存があれば作らない)。べき等。
+      await ddb.send(new PutItemCommand({
+        TableName: TABLE, Item: item, ConditionExpression: 'attribute_not_exists(imageId)',
+      }));
+      created += 1;
+      console.log(`[${created + skipped}/${orphans.length}] registered ${key}`);
+    } catch (e) {
+      if (e.name === 'ConditionalCheckFailedException') { skipped += 1; continue; }
+      throw e;
+    }
+  }
+  console.log(`完了: 登録 ${created} / 既存スキップ ${skipped}`);
+  console.log('次: scripts/backfill-enrich.mjs を回すとこれらが enrich される。');
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## 背景
バケットに画像600枚あるが、メタデータDB(DynamoDB)に登録されているのは520枚。差の**80枚は全部 JPG/JPEG**（2021〜2024アップ）。本アプリは PNG 前提（upload は PNG のみ受理・S3トリガも `.png`）のため、これらはメタデータ登録されず**タグ・検索の対象外**だった。

## このスクリプト
`scripts/register-orphan-images.mjs`: バケット画像とDDBを突き合わせ、レコードが無い画像に upload と同じ基本レコード（`{imageId, uploadedAt, visibility=private}`）を作る。べき等（既存は上書きしない）。タグ/埋め込みは作らず、後続の `backfill-enrich.mjs` に任せる（enrich は #39 で JPEG 対応済み）。`@aws-sdk/client-s3` を scripts 依存に追加。

## 実行順（ローカル・apply不要）
```
cd scripts && npm install
aws sso login --profile dev
AWS_PROFILE=dev REGION=ap-northeast-1 node scripts/register-orphan-images.mjs   # 80枚を登録
AWS_PROFILE=dev REGION=ap-northeast-1 CONCURRENCY=1 node scripts/backfill-enrich.mjs  # enrich
aws lambda invoke --function-name WIPUploaderUpdateImagesJsonFunction --payload '{}' \
  --cli-binary-format raw-in-base64-out --profile dev --region ap-northeast-1 /tmp/upd.json
```
→ 600枚すべてが検索・タグ対象に。dry-run で 80枚特定を確認済み。