### PR TITLE
feat(terraform): migrate state to S3 backend + stop bucket-policy drift

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,6 +58,9 @@ resource "aws_s3_bucket_policy" "image_bucket" {
   bucket = aws_s3_bucket.image_bucket.id
 
   policy = jsonencode({
+    # S3 auto-injects a policy Version if omitted, causing a perpetual plan diff.
+    # Pin it explicitly so config matches what AWS stores.
+    Version = "2012-10-17"
     Statement = [
       {
         Action = "s3:GetObject"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,5 +1,18 @@
 terraform {
   required_version = ">= 1.5" # For config-driven imports
+
+  # Remote state in S3 so the same state is shared from the Mac, remote
+  # containers, or CI. Terraform 1.10+ native S3 locking (use_lockfile) means
+  # no separate DynamoDB lock table is needed. Credentials resolve via the
+  # standard AWS chain (AWS_PROFILE=dev locally, OIDC role in CI).
+  backend "s3" {
+    bucket       = "sketch-stacker-tfstate-791464527050"
+    key          = "sketch-stacker/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
## What

- **Remote state → S3.** Terraform state now lives in a versioned, encrypted, public-access-blocked S3 bucket (`sketch-stacker-tfstate-791464527050`, ap-northeast-1) instead of only on one machine. This unblocks running `terraform plan/apply` against the **same** state from the Mac, remote containers, or CI.
- **Native locking.** Uses Terraform 1.10+ `use_lockfile` (native S3 lock) — no DynamoDB lock table needed.
- **Bucket-policy drift fixed.** Pinned the S3 bucket-policy `Version` to `2012-10-17`. S3 auto-injects a policy `Version` when omitted, which caused a perpetual in-place plan diff; pinning it makes `plan` converge to `No changes`.

## Why

Enables infra operations from anywhere (goal: iPhone / remote container), and removes single-machine state as a bottleneck / loss risk.

## Verification

- `terraform init -migrate-state` copied local state → S3 (152593 bytes, matches local).
- `terraform plan` with locking enabled: **`No changes. Your infrastructure matches the configuration.`**
- State bucket has versioning + SSE (AES256) + full public-access block enabled.

## Notes

- Credentials resolve via the standard AWS chain (`AWS_PROFILE=dev` locally; OIDC role in CI later).
- The local `terraform/terraform.tfstate` is now orphaned (S3 is source of truth) and remains only as a gitignored backup.
- **Next enabler** for the remote/CI goal: GitHub Actions + OIDC keyless auth (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)