### PR TITLE
fix(upload): accept JPEG/GIF/WebP so iPhone photos upload (was PNG-only)

### DIFF
--- a/terraform/lambda-functions/upload/index.js
+++ b/terraform/lambda-functions/upload/index.js
@@ -5,6 +5,26 @@ const s3Client = new S3Client({ region: process.env.AWS_DEFAULT_REGION });
 const ddb = new DynamoDBClient({ region: process.env.AWS_DEFAULT_REGION });
 const lambda = new LambdaClient({ region: process.env.AWS_DEFAULT_REGION });
 
+// アップロード可能な画像形式をマジックバイトで判定する。
+// #20 の「中身が本当に画像か」を担保しつつ、PNG に加え iPhone 由来の JPEG など
+// 下流(enrich #39・ギャラリー表示)が既に対応する形式も受理する。
+// 未知/非画像は null（拒否）。ext と MIME を返し、正しい拡張子・Content-Type で保存する。
+function detectImageType(buf) {
+  if (buf.length >= 8 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return { ext: 'png', mime: 'image/png' };
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return { ext: 'jpg', mime: 'image/jpeg' };
+  if (buf.length >= 4 && buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x38) return { ext: 'gif', mime: 'image/gif' };
+  if (buf.length >= 12 && buf.toString('ascii', 0, 4) === 'RIFF' && buf.toString('ascii', 8, 12) === 'WEBP') return { ext: 'webp', mime: 'image/webp' };
+  return null;
+}
+
+// HEIC/HEIF（iPhone 標準フォーマット）は Bedrock もブラウザも表示不可のため受理しない。
+// 「PNGではない」という不親切なエラーではなく具体的な対処を返すために別途判定する。
+function isHeic(buf) {
+  if (buf.length < 12 || buf.toString('ascii', 4, 8) !== 'ftyp') return false;
+  const brand = buf.toString('ascii', 8, 12);
+  return ['heic', 'heix', 'hevc', 'heim', 'heis', 'hevm', 'hevs', 'mif1', 'msf1'].includes(brand);
+}
+
 exports.handler = async (event) => {
   try {
     const body = JSON.parse(event.body);
@@ -30,23 +50,28 @@ exports.handler = async (event) => {
       };
     }
 
-    // #20: PNGマジックバイト(89 50 4E 47 0D 0A 1A 0A)を検証し、中身がPNG以外の保存を拒否
-    const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-    if (imageData.length < 8 || !imageData.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    // #20 の意図(中身が本当に画像か)を維持しつつ、対応形式を PNG/JPEG/GIF/WebP に拡張。
+    // マジックバイトで判定し、未知形式は拒否。HEIC は具体的な対処を促す。
+    const imageType = detectImageType(imageData);
+    if (!imageType) {
       return {
         statusCode: 400,
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ error: 'Uploaded data is not a valid PNG image' })
+        body: JSON.stringify({
+          error: isHeic(imageData)
+            ? 'HEIC/HEIF は非対応です。iPhone の「設定 > カメラ > フォーマット」を「互換性優先」にする（JPEGで撮影）か、JPEG/PNG に変換してアップロードしてください。'
+            : 'Unsupported image format. PNG / JPEG / GIF / WebP のみ対応しています。'
+        })
       };
     }
 
-    const key = `${Date.now()}.png`;
+    const key = `${Date.now()}.${imageType.ext}`;
 
     const command = new PutObjectCommand({
       Bucket: process.env.BUCKET_NAME,
       Key: key,
       Body: imageData,
-      ContentType: 'image/png',
+      ContentType: imageType.mime,
       StorageClass: 'GLACIER_IR'
     });
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,14 +3,14 @@
 
 # Resource IDs from CloudFormation stack discovery
 locals {
-  api_gateway_id               = "3p4utkstnb"
-  upload_function_name         = "WIPUploader-UploadFunction-hJDSjvqD9eM7"
-  authorizer_function_name     = "WIPUploader-AuthorizerFunction-7WKXvtdhJ2Lx"
-  update_images_function_name  = "WIPUploaderUpdateImagesJsonFunction"
-  upload_execution_role_name   = "WIPUploader-UploadLambdaExecutionRole-pepPv9zSfzBh"
-  update_execution_role_name   = "WIPUploader-UpdateImagesJsonLambdaExecutionRole-MhwPNOwZDB5j"
-  secrets_manager_arn          = "arn:aws:secretsmanager:ap-northeast-1:791464527050:secret:WIPUploaderSecret-SWNxHU"
-  oac_id                       = "E1Y0EK4C9ZX47D"
+  api_gateway_id              = "3p4utkstnb"
+  upload_function_name        = "WIPUploader-UploadFunction-hJDSjvqD9eM7"
+  authorizer_function_name    = "WIPUploader-AuthorizerFunction-7WKXvtdhJ2Lx"
+  update_images_function_name = "WIPUploaderUpdateImagesJsonFunction"
+  upload_execution_role_name  = "WIPUploader-UploadLambdaExecutionRole-pepPv9zSfzBh"
+  update_execution_role_name  = "WIPUploader-UpdateImagesJsonLambdaExecutionRole-MhwPNOwZDB5j"
+  secrets_manager_arn         = "arn:aws:secretsmanager:ap-northeast-1:791464527050:secret:WIPUploaderSecret-SWNxHU"
+  oac_id                      = "E1Y0EK4C9ZX47D"
   cors_policy_id              = "4f6ab204-bbcb-4a16-bb18-fb14748b8d29"
   api_resource_id             = "zu6l15"
   api_authorizer_id           = "b8w9lx"
@@ -63,9 +63,9 @@ resource "aws_s3_bucket_policy" "image_bucket" {
     Version = "2012-10-17"
     Statement = [
       {
-        Action = "s3:GetObject"
-        Effect = "Allow"
-        Resource = "${aws_s3_bucket.image_bucket.arn}/*"
+        Action    = "s3:GetObject"
+        Effect    = "Allow"
+        Resource  = "${aws_s3_bucket.image_bucket.arn}/*"
         Principal = "*"
         Condition = {
           StringEquals = {
@@ -80,11 +80,33 @@ resource "aws_s3_bucket_policy" "image_bucket" {
 resource "aws_s3_bucket_notification" "image_bucket" {
   bucket = aws_s3_bucket.image_bucket.id
 
+  # 画像のアップロード/削除だけをトリガーにする。update-images が書き戻す
+  # images.json / viewer/*.json は .json 拡張子なのでどのルールにも一致せず自己再帰しない。
+  # S3 は同一イベントで filter_suffix を重複できないため、対応形式ごとに1ブロック並べる。
   lambda_function {
     lambda_function_arn = aws_lambda_function.update_images_json.arn
     events              = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
-    # 画像(.png)のアップロード/削除のみトリガー。images.json(.json)の書き戻しでは発火させず自己再帰を防ぐ
     filter_suffix       = ".png"
+  }
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.update_images_json.arn
+    events              = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+    filter_suffix       = ".jpg"
+  }
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.update_images_json.arn
+    events              = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+    filter_suffix       = ".jpeg"
+  }
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.update_images_json.arn
+    events              = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+    filter_suffix       = ".gif"
+  }
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.update_images_json.arn
+    events              = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+    filter_suffix       = ".webp"
   }
 
   depends_on = [aws_lambda_permission.s3_invoke_update_lambda]
@@ -181,7 +203,7 @@ resource "aws_cloudfront_response_headers_policy" "cors" {
     }
 
     access_control_max_age_sec = 600
-    origin_override           = true
+    origin_override            = true
   }
 }
 
@@ -233,7 +255,7 @@ resource "aws_cloudfront_distribution" "main" {
 # IAM ROLES
 # =====================================================================================
 resource "aws_iam_role" "upload_lambda_execution" {
-  name = "WIPUploader-UploadLambdaExecutionRole-pepPv9zSfzBh"  # Preserve CloudFormation name
+  name = "WIPUploader-UploadLambdaExecutionRole-pepPv9zSfzBh" # Preserve CloudFormation name
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -322,7 +344,7 @@ resource "aws_iam_role" "authorizer_lambda_execution" {
 }
 
 resource "aws_iam_role" "update_lambda_execution" {
-  name = "WIPUploader-UpdateImagesJsonLambdaExecutionRole-MhwPNOwZDB5j"  # Preserve CloudFormation name
+  name = "WIPUploader-UpdateImagesJsonLambdaExecutionRole-MhwPNOwZDB5j" # Preserve CloudFormation name
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -425,8 +447,8 @@ resource "aws_iam_role" "enrich_lambda_execution" {
           ]
         },
         {
-          Effect = "Allow"
-          Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+          Effect   = "Allow"
+          Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
           Resource = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.stack_name}-ImageEnrichFunction:*"
         }
       ]
@@ -440,20 +462,20 @@ resource "aws_iam_role" "enrich_lambda_execution" {
 # LAMBDA FUNCTIONS
 # =====================================================================================
 resource "aws_lambda_function" "upload" {
-  function_name = "WIPUploader-UploadFunction-hJDSjvqD9eM7"  # Preserve CloudFormation name
+  function_name = "WIPUploader-UploadFunction-hJDSjvqD9eM7" # Preserve CloudFormation name
   handler       = "index.handler"
-  role         = aws_iam_role.upload_lambda_execution.arn
-  runtime      = "nodejs22.x"
-  timeout      = 10
+  role          = aws_iam_role.upload_lambda_execution.arn
+  runtime       = "nodejs22.x"
+  timeout       = 10
 
   filename         = data.archive_file.upload_lambda.output_path
   source_code_hash = data.archive_file.upload_lambda.output_base64sha256
 
   environment {
     variables = {
-      BUCKET_NAME      = aws_s3_bucket.image_bucket.id
-      CLOUDFRONT_DOMAIN = aws_cloudfront_distribution.main.domain_name
-      METADATA_TABLE    = aws_dynamodb_table.image_metadata.name
+      BUCKET_NAME          = aws_s3_bucket.image_bucket.id
+      CLOUDFRONT_DOMAIN    = aws_cloudfront_distribution.main.domain_name
+      METADATA_TABLE       = aws_dynamodb_table.image_metadata.name
       ENRICH_FUNCTION_NAME = aws_lambda_function.image_enrich.function_name
     }
   }
@@ -489,10 +511,10 @@ resource "aws_lambda_function" "image_enrich" {
 }
 
 resource "aws_lambda_function" "authorizer" {
-  function_name = "WIPUploader-AuthorizerFunction-7WKXvtdhJ2Lx"  # Preserve CloudFormation name
+  function_name = "WIPUploader-AuthorizerFunction-7WKXvtdhJ2Lx" # Preserve CloudFormation name
   handler       = "index.handler"
-  role         = aws_iam_role.authorizer_lambda_execution.arn
-  runtime      = "nodejs22.x"
+  role          = aws_iam_role.authorizer_lambda_execution.arn
+  runtime       = "nodejs22.x"
 
   filename         = data.archive_file.authorizer_lambda.output_path
   source_code_hash = data.archive_file.authorizer_lambda.output_base64sha256
@@ -508,18 +530,18 @@ resource "aws_lambda_function" "authorizer" {
 }
 
 resource "aws_lambda_function" "update_images_json" {
-  function_name = "WIPUploaderUpdateImagesJsonFunction"  # Preserve CloudFormation name
+  function_name = "WIPUploaderUpdateImagesJsonFunction" # Preserve CloudFormation name
   handler       = "index.handler"
-  role         = aws_iam_role.update_lambda_execution.arn
-  runtime      = "nodejs22.x"
-  timeout      = 300
+  role          = aws_iam_role.update_lambda_execution.arn
+  runtime       = "nodejs22.x"
+  timeout       = 300
 
   filename         = data.archive_file.update_images_lambda.output_path
   source_code_hash = data.archive_file.update_images_lambda.output_base64sha256
 
   environment {
     variables = {
-      IMAGE_BUCKET               = var.image_bucket_name
+      IMAGE_BUCKET              = var.image_bucket_name
       DISTRIBUTION_ID           = var.cloudfront_distribution_id
       IMAGES_JSON_FILENAME_PATH = var.images_json_filename_path
       METADATA_TABLE            = aws_dynamodb_table.image_metadata.name
@@ -743,15 +765,15 @@ resource "aws_lambda_permission" "api_gateway_invoke_authorizer" {
   function_name = aws_lambda_function.authorizer.function_name
   principal     = "apigateway.amazonaws.com"
   # #18: 同一アカウントの任意APIから呼べないよう、このAPIのこのauthorizerに限定
-  source_arn    = "${aws_api_gateway_rest_api.main.execution_arn}/authorizers/${aws_api_gateway_authorizer.basic_auth.id}"
+  source_arn = "${aws_api_gateway_rest_api.main.execution_arn}/authorizers/${aws_api_gateway_authorizer.basic_auth.id}"
 }
 
 resource "aws_lambda_permission" "s3_invoke_update_lambda" {
-  statement_id  = "AllowExecutionFromS3Bucket"
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.update_images_json.function_name
-  principal     = "s3.amazonaws.com"
-  source_arn    = aws_s3_bucket.image_bucket.arn
+  statement_id   = "AllowExecutionFromS3Bucket"
+  action         = "lambda:InvokeFunction"
+  function_name  = aws_lambda_function.update_images_json.function_name
+  principal      = "s3.amazonaws.com"
+  source_arn     = aws_s3_bucket.image_bucket.arn
   source_account = data.aws_caller_identity.current.account_id
 }
 
@@ -1160,9 +1182,9 @@ resource "aws_lambda_function" "memos" {
 
   environment {
     variables = {
-      METADATA_TABLE          = aws_dynamodb_table.image_metadata.name
-      ALLOWED_ORIGIN          = var.admin_allowed_origin
-      UPDATE_IMAGES_FUNCTION  = aws_lambda_function.update_images_json.function_name
+      METADATA_TABLE         = aws_dynamodb_table.image_metadata.name
+      ALLOWED_ORIGIN         = var.admin_allowed_origin
+      UPDATE_IMAGES_FUNCTION = aws_lambda_function.update_images_json.function_name
     }
   }
 


### PR DESCRIPTION
## Problem
Uploading an iPhone photo failed with **`Uploaded data is not a valid PNG image`**. The upload Lambda only accepted PNG (magic-byte check from the #20/#26 security fix), but iPhone photos are JPEG/HEIC.

This was **not** introduced by the recent infra work (#41/#42 never touched the upload code) — it's the pre-existing PNG-only allowlist from `fix(sec) ... (#20) (#26)`. But it's a real inconsistency worth fixing: the rest of the pipeline already handles JPEG (enrich format detection #39, orphan-JPEG registration #40) — only the entrypoint blocked it.

## Fix
- **`upload/index.js`**: detect the image type by magic bytes (PNG / JPEG / GIF / WebP) and save with the correct extension + `Content-Type` (was hardcoded `.png` / `image/png`). Preserves the #20 intent (must be a real image, ≤10 MB) and still rejects unknown/non-image data. **HEIC/HEIF** returns an actionable message (switch iPhone to “most compatible”/JPEG, or convert) instead of the misleading PNG error.
- **`main.tf`**: the S3 notification fired `update-images` only on `.png`, so non-PNG uploads never reached `images.json`/the gallery. Added `.jpg/.jpeg/.gif/.webp` suffix rules (distinct suffixes → no S3 overlap; `update-images` already lists all non-`viewer/` keys). Now non-PNG images appear in / disappear from the gallery just like PNGs.

## Verified
- `node -c upload/index.js` OK.
- `terraform validate` OK (only pre-existing `inline_policy` deprecation warnings).
- End-to-end reasoning: upload(JPEG) → S3 `.jpg` → `update-images` → `images.json` includes it → gallery `<img>` renders JPEG; enrich already format-aware (#39).

## Note on HEIC
If the iPhone was set to HEIC, this still won't store it (Bedrock and browsers can't display HEIC) — but the error now tells you exactly what to do. Transparent JPEG conversion could be a follow-up if needed.

## Deploy
CI-authoritative: on merge, the Terraform workflow applies (redeploys `upload` + updates the S3 notification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)