### PR TITLE
fix(memos,delete): accept JPEG/GIF/WebP keys (was .png-only)

### DIFF
--- a/terraform/lambda-functions/delete/index.js
+++ b/terraform/lambda-functions/delete/index.js
@@ -13,8 +13,9 @@ exports.handler = async (event) => {
   const rawKey = event.pathParameters && event.pathParameters.key;
   const key = rawKey ? decodeURIComponent(rawKey) : '';
 
-  // 安全策: ルート直下の画像(.png)のみ削除可。viewer/images.json やフォルダは対象外
-  if (!key || key.includes('/') || !key.endsWith('.png')) {
+  // 安全策: ルート直下の対応画像形式のみ削除可。viewer/images.json やフォルダは対象外
+  // 対応拡張子は upload(#46) と揃える: png/jpg/jpeg/gif/webp
+  if (!key || key.includes('/') || !/\.(png|jpe?g|gif|webp)$/i.test(key)) {
     return {
       statusCode: 400,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },

--- a/terraform/lambda-functions/memos/index.js
+++ b/terraform/lambda-functions/memos/index.js
@@ -30,8 +30,9 @@ exports.handler = async (event) => {
 
   const rawKey = event.pathParameters && event.pathParameters.key;
   const key = rawKey ? decodeURIComponent(rawKey) : '';
-  // 安全策: ルート直下の画像(.png)のみ対象。viewer/配下やフォルダは対象外。
-  if (!key || key.includes('/') || !key.endsWith('.png')) {
+  // 安全策: ルート直下の対応画像形式のみ対象。viewer/配下やフォルダは対象外。
+  // 対応拡張子は upload(#46) と揃える: png/jpg/jpeg/gif/webp
+  if (!key || key.includes('/') || !/\.(png|jpe?g|gif|webp)$/i.test(key)) {
     return respond(400, { error: 'Invalid image key' });
   }
 


### PR DESCRIPTION
## Problem
Memo save/load (and delete) on newly uploaded JPEG images returned **400 Invalid image key**: #46 extended *upload* to JPEG/GIF/WebP, but the `memos` and `delete` Lambdas still validated keys with `endsWith('.png')`.

(Diagnosed from the reported browser error on `GET/PUT /memos/1783609162417.jpg`. Note: the visible "CORS policy" error itself is the authorizer 403 masking — the user's admin session was still on the old password; API GW error responses carry no CORS headers. Logging in with the new admin password fixes that part; this PR fixes the 400 that would hit next.)

## Fix
Align key validation with the upload allowlist: `/\.(png|jpe?g|gif|webp)$/i`, keeping the `includes('/')` path guard.

## Verify after merge
- `GET /memos/1783609162417.jpg` with admin creds → 200 (was 400)
- `PUT /memos/1783609162417.jpg` → saves
- `.png` keys unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)