### PR TITLE
fix(memos,delete): accept JPEG/GIF/WebP image keys (was PNG-only)

### DIFF
--- a/terraform/lambda-functions/delete/index.js
+++ b/terraform/lambda-functions/delete/index.js
@@ -13,8 +13,10 @@ exports.handler = async (event) => {
   const rawKey = event.pathParameters && event.pathParameters.key;
   const key = rawKey ? decodeURIComponent(rawKey) : '';
 
-  // 安全策: ルート直下の画像(.png)のみ削除可。viewer/images.json やフォルダは対象外
-  if (!key || key.includes('/') || !key.endsWith('.png')) {
+  // 安全策: ルート直下の画像のみ削除可。viewer/images.json やフォルダは対象外。
+  // 拡張子は upload(#46)が受理する形式に揃える(png/jpg/jpeg/gif/webp)。
+  // .png 決め打ちだと JPEG 画像が削除できない。
+  if (!key || key.includes('/') || !/\.(png|jpe?g|gif|webp)$/i.test(key)) {
     return {
       statusCode: 400,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },

--- a/terraform/lambda-functions/memos/index.js
+++ b/terraform/lambda-functions/memos/index.js
@@ -30,8 +30,10 @@ exports.handler = async (event) => {
 
   const rawKey = event.pathParameters && event.pathParameters.key;
   const key = rawKey ? decodeURIComponent(rawKey) : '';
-  // 安全策: ルート直下の画像(.png)のみ対象。viewer/配下やフォルダは対象外。
-  if (!key || key.includes('/') || !key.endsWith('.png')) {
+  // 安全策: ルート直下の画像のみ対象。viewer/配下やフォルダは対象外。
+  // 拡張子は upload(#46)が受理する形式に揃える(png/jpg/jpeg/gif/webp)。
+  // .png 決め打ちだと JPEG 画像のメモ取得/保存が 400 で弾かれる。
+  if (!key || key.includes('/') || !/\.(png|jpe?g|gif|webp)$/i.test(key)) {
     return respond(400, { error: 'Invalid image key' });
   }
 


### PR DESCRIPTION
重複のためクローズ。同じ memos/delete の `.jpg` 修正は #48 に含まれており、#48 は現在の main ベースで差分が memos/delete のみとクリーン。本PRは古い main から分岐しており authorizer/main.tf に紛らわしい差分が出るため、#48 に一本化する。

→ **#48 をマージしてください。**