### PR TITLE
feat(photos): バリュー確認を check-value-app 連携に変更（モノクロトグル廃止）

### DIFF
--- a/terraform/photos.tf
+++ b/terraform/photos.tf
@@ -39,6 +39,23 @@ resource "aws_s3_bucket_versioning" "photo_bucket" {
   }
 }
 
+# check-value-app（別オリジン）が presigned URL の写真を crossOrigin で読み込むための CORS。
+# 認可は presigned URL の署名が担う（CORSは「どのオリジンのJSが読めるか」の制御であり公開ではない）。
+resource "aws_s3_bucket_cors_configuration" "photo_bucket" {
+  bucket = aws_s3_bucket.photo_bucket.id
+
+  cors_rule {
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = [
+      "https://odayakalife.dev",  # check-value-app / 管理ギャラリー
+      "https://trkoh.github.io",  # 旧管理ギャラリー
+      "http://localhost:*",       # ローカル開発
+    ]
+    allowed_headers = ["*"]
+    max_age_seconds = 600
+  }
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "photo_bucket" {
   bucket = aws_s3_bucket.photo_bucket.id
 

--- a/viewer-react/src/components/PhotoGallery.jsx
+++ b/viewer-react/src/components/PhotoGallery.jsx
@@ -4,13 +4,14 @@ import Modal from './Modal';
 
 // U-P1: リファレンス写真ビュー（管理モード限定）。
 // GET /photos（Basic認証）で一覧＋期限付き presigned URL を取得して表示する。
-// 写真は常に非公開（公開CDNには存在しない）。撮影メモの編集・削除・モノクロ表示（バリュー確認の
-// 最小導線 = check-value 思想）を備える。
+// 写真は常に非公開（公開CDNには存在しない）。撮影メモの編集・削除に加え、
+// バリュー確認は自作 check-value-app に presigned URL を ?img= で渡して別タブで開く。
+const CHECK_VALUE_APP = 'https://odayakalife.dev/check-value-app/';
+
 const PhotoGallery = ({ admin, apiBase }) => {
   const [photos, setPhotos] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [mono, setMono] = useState(false); // モノクロ表示（バリュー確認用）
   const [modal, setModal] = useState(null); // {url, memo}
   const [memoEditor, setMemoEditor] = useState(null); // {photoId, memo, saving, error}
 
@@ -88,9 +89,6 @@ const PhotoGallery = ({ admin, apiBase }) => {
         <span style={{ fontSize: '0.9rem', color: '#666' }}>
           リファレンス写真（非公開・{photos.length}枚）
         </span>
-        <button style={{ ...btnStyle, background: mono ? '#2c3e50' : '#888' }} onClick={() => setMono(m => !m)}>
-          {mono ? 'カラーに戻す' : 'モノクロ表示（バリュー確認）'}
-        </button>
         <button style={btnStyle} onClick={fetchPhotos}>再読込</button>
       </div>
 
@@ -109,7 +107,6 @@ const PhotoGallery = ({ admin, apiBase }) => {
               src={p.url}
               alt={p.photoId}
               loading="lazy"
-              style={mono ? { filter: 'grayscale(1)' } : undefined}
               onClick={() => setModal({ url: p.url, memo: p.memo })}
             />
             <button
@@ -125,6 +122,14 @@ const PhotoGallery = ({ admin, apiBase }) => {
               style={{ position: 'absolute', top: 4, left: 54, background: '#2c3e50', color: '#fff', zIndex: 2, opacity: 1, visibility: 'visible' }}
             >
               メモ
+            </button>
+            <button
+              className="ctrl-btn"
+              onClick={() => window.open(`${CHECK_VALUE_APP}?img=${encodeURIComponent(p.url)}`, '_blank', 'noopener')}
+              title="check-value-app でバリュー確認（グレースケール/Notan/ポスタリゼーション）"
+              style={{ position: 'absolute', top: 4, left: 104, background: '#7d3c98', color: '#fff', zIndex: 2, opacity: 1, visibility: 'visible' }}
+            >
+              Value
             </button>
             {p.memo && (
               <div className="memo-preview" onClick={() => setModal({ url: p.url, memo: p.memo })}>


### PR DESCRIPTION
## 概要
写真ビューの「モノクロ表示トグル」(CSSフィルタ)を廃止し、各写真タイルに **「Value」ボタン**を追加。押すと自作 [check-value-app](https://odayakalife.dev/check-value-app/) を**別タブで開き、その写真を渡す**(グレースケール/Notan/ポスタリゼーションでのバリュー確認)。

## 実装
- **フロント**: `PhotoGallery.jsx` — check-value-app の実コードを確認し、`?img=<URL>` パラメータを直接サポートしていること(`params.get('img')`＋`crossOrigin`読込)を確認済み。presigned URL を `?img=` に渡して `window.open`。
- **Terraform**: 写真バケットに CORS ルール追加(GET/HEAD、origins: odayakalife.dev / trkoh.github.io / localhost)。check-value-app が crossOrigin で読むために必須(これが無いと読み込み失敗)。**認可は従来どおり presigned 署名のみ**(CORSは読み取り元JSのオリジン制御であり公開化ではない)。

## 注意
presigned URL の有効期限は600秒。写真ビューを開いてから10分以上経った後に Value を押すと期限切れで読み込めない → 「再読込」ボタンで新しいURLを取得してから押す。

## 反映
マージ → terraform apply(CORS)＋Pages デプロイ後、写真ビューの各タイルに Value ボタンが出る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015GA9DSBjLQiwjyrnAB5xm9)_