### PR TITLE
feat(link): U-P2 写真↔絵の類似サジェスト＋手動紐づけ

### DIFF
--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -20,3 +20,10 @@
 **AI Response**: ADR-006を裁定済みに更新（別バケット/presigned URL/POST /photos＋アップロード=iOSショートカット。根拠: PWA Share TargetはiOS未対応、S3クライアントアプリは長期AWSキー保存が鍵レス方針と矛盾、自作Share Extensionは過剰投資）。U-P1実装: photos Lambda（POST/GET/PUT/DELETE・マジックバイト検証・presigned URL 600s）、非公開バケット＋PhotoMetadataテーブル（絵と完全分離）、API GW /photos系＋CORS、authorizer許可追加（uploader=POST/photosのみ、admin=全部）、管理UIに写真ビュー（一覧・メモ編集・削除・モノクロ表示トグル）、ショートカットレシピ docs/ios-shortcut-photos.md。
 **Context**: Construction（U-P1）。lint 0 errors・build成功。
 ---
+
+## Phase 2 U-P2 実装（類似サジェスト＆紐づけ）
+**Timestamp**: 2026-07-12T03:30:00Z
+**User Input**: 「いけました / イラストとリファレンスを紐づけるという話は？ / あとヴァリュー確認のロジックが意味不明 https://odayakalife.dev/check-value-app/?paste=1 これに画像差し込んで別タブで開くということをしろ」→「52mergeした 進めろ」
+**AI Response**: ①check-value-app実コードを取得し `?img=` パラメータ対応を確認、Valueボタン＋写真バケットCORSで連携(PR #52)。②U-P2実装: enrich写真モード(埋め込みのみ)、photosアップロード時の非同期invoke、GET /photosにembedding/linkedImages、PUT /photosにlinkImageAdd/Remove(両テーブル相互保存)、GET /memosにrefPhotos、UI(似た絵サジェストパネル・紐づけトグル・写真タイルに絵サムネ・絵モーダルに参照写真)。ADR-007記録。
+**Context**: Construction（U-P2）。lint 0 errors・build成功。
+---

--- a/aidlc-docs/inception/adr/adrs.md
+++ b/aidlc-docs/inception/adr/adrs.md
@@ -158,3 +158,14 @@ iOS Shortcut(写真用) → POST /photos (Basic認証)
 - 保存=別バケット / 配信=presigned URL / エンドポイント=新設 `/photos` を採用。
 - **アップロード経路の追加裁定**: オーナー要件「Appleの共有シートから1タップ」が確定。共有シート統合の全手段を調査した結果 **iOSショートカット** を採用（PWA Web Share TargetはiOS未対応 [WebKit#194593]、サードパーティS3アプリは長期AWSキーを他社アプリに置く必要があり鍵レス方針(#42)と矛盾、自作Share Extensionは$99/年+開発保守が単一ユーザーに過剰）。
 - 画像はショートカット側で長辺2048pxへリサイズ（API GW 10MB制限対策。原寸はiCloud写真に残存）。レシピ: `docs/ios-shortcut-photos.md`。
+
+---
+
+## ADR-007：写真↔絵の類似サジェスト＆紐づけ（Phase 2 U-P2・2026-07-12 オーナー「進めろ」指示に基づき既裁定パターン踏襲）
+
+- **埋め込み生成**: 写真アップロード時に photos Lambda が既存 enrich Lambda を**写真モード**（`{kind:'photo'}`・埋め込みのみ・タグ生成なし）で非同期invoke（U2のA案=非同期パターンの再利用。コスト $0.0001/枚）。
+- **類似計算**: **ブラウザ内コサイン総当たり**（ADR-002踏襲）。絵側ベクトル=公開 `embeddings.json`、写真側ベクトル=`GET /photos`（管理者限定）が返す。**写真の埋め込みは公開JSONに出さない**。
+- **紐づけデータモデル**: 相互保存 — 写真 `PhotoMetadata.linkedImages`(SS) ⇄ 絵 `ImageMetadata.refPhotos`(SS)。更新は `PUT /photos/{key}` の `linkImageAdd`/`linkImageRemove`（管理者限定・photos Lambda が両テーブルを更新）。
+- **公開射影の安全性**: update-images は明示フィールドのみ射影するため `refPhotos` は公開 metadata.json に出ない（写真IDも非公開扱いを維持）。
+- **UI**: 写真タイル「似た絵」→類似上位12件をパネル表示→タップで紐づけ⇄解除。写真タイルに紐づけ済みの絵サムネ、絵の拡大モーダルに紐づけ済み参照写真（管理モード時のみ）。
+- **既知の割り切り**: 写真削除時に絵側 refPhotos の後始末はしない（表示時に解決不能IDを無視）。必要になったら削除時クリーンアップを追加。

--- a/terraform/lambda-functions/image-enrich/index.js
+++ b/terraform/lambda-functions/image-enrich/index.js
@@ -155,6 +155,9 @@ async function generateTags(b64, format) {
 /**
  * 1枚の画像を処理してメタデータを更新する。upload非同期invoke / バックフィル共通のエントリ。
  * イベント形は { imageId: "<timestamp>.png" } を想定。
+ * U-P2: { imageId, kind: "photo" } の場合はリファレンス写真モード —
+ * 写真バケット/写真テーブルを対象に「埋め込みのみ」生成する（タグは写真には不要。
+ * 埋め込みは絵↔写真の類似サジェスト用で、公開射影には一切出ない）。
  */
 exports.handler = async (event) => {
   const imageId = event && event.imageId;
@@ -162,14 +165,21 @@ exports.handler = async (event) => {
     console.error('imageId missing in event:', JSON.stringify(event));
     return { ok: false, error: 'imageId required' };
   }
+  const isPhoto = event.kind === 'photo';
+  const bucket = isPhoto ? process.env.PHOTO_BUCKET : process.env.IMAGE_BUCKET;
+  const table = isPhoto ? process.env.PHOTO_TABLE : process.env.METADATA_TABLE;
+  const keyAttr = isPhoto ? 'photoId' : 'imageId';
 
-  const bytes = await getImageBytes(process.env.IMAGE_BUCKET, imageId);
+  const bytes = await getImageBytes(bucket, imageId);
   const b64 = bytes.toString('base64');
   // 拡張子が .png でも中身が JPEG 等のことがあるので実バイトで形式判定して Bedrock に渡す。
   const format = detectImageFormat(bytes);
 
-  // 埋め込みとタグは独立なので並列化(片方失敗でも他方は活かす)。
-  const [embedResult, tagResult] = await Promise.allSettled([embedImage(b64, format), generateTags(b64, format)]);
+  // 埋め込みとタグは独立なので並列化(片方失敗でも他方は活かす)。写真はタグ不要のためスキップ。
+  const [embedResult, tagResult] = await Promise.allSettled([
+    embedImage(b64, format),
+    isPhoto ? Promise.resolve([]) : generateTags(b64, format),
+  ]);
 
   const exprNames = {};
   const exprValues = {};
@@ -202,8 +212,8 @@ exports.handler = async (event) => {
   setClauses.push('#ea = :ea');
 
   await ddb.send(new UpdateItemCommand({
-    TableName: process.env.METADATA_TABLE,
-    Key: { imageId: { S: imageId } },
+    TableName: table,
+    Key: { [keyAttr]: { S: imageId } },
     UpdateExpression: 'SET ' + setClauses.join(', '),
     ExpressionAttributeNames: exprNames,
     ExpressionAttributeValues: exprValues,

--- a/terraform/lambda-functions/memos/index.js
+++ b/terraform/lambda-functions/memos/index.js
@@ -41,15 +41,19 @@ exports.handler = async (event) => {
       do {
         const res = await ddb.send(new ScanCommand({
           TableName: process.env.METADATA_TABLE,
-          ProjectionExpression: 'imageId, memo, visibility',
+          // refPhotos は U-P2 の絵↔写真リンク。管理UIが絵側から参照写真を辿るために返す
+          // （このエンドポイントは管理者限定。公開射影 metadata.json には出ない）。
+          ProjectionExpression: 'imageId, memo, visibility, refPhotos',
           ExclusiveStartKey: lastKey,
         }));
         for (const it of res.Items || []) {
-          if (it.memo && it.memo.S) {
+          const refPhotos = (it.refPhotos && it.refPhotos.SS) || [];
+          if ((it.memo && it.memo.S) || refPhotos.length > 0) {
             memos.push({
               imageId: it.imageId.S,
-              memo: it.memo.S,
+              memo: (it.memo && it.memo.S) || '',
               visibility: (it.visibility && it.visibility.S) || 'private',
+              refPhotos,
             });
           }
         }

--- a/terraform/lambda-functions/photos/index.js
+++ b/terraform/lambda-functions/photos/index.js
@@ -9,9 +9,11 @@
 const { S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand } = require('@aws-sdk/client-s3');
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 const { DynamoDBClient, PutItemCommand, ScanCommand, UpdateItemCommand, DeleteItemCommand } = require('@aws-sdk/client-dynamodb');
+const { LambdaClient, InvokeCommand } = require('@aws-sdk/client-lambda');
 
 const s3 = new S3Client({ region: process.env.AWS_DEFAULT_REGION });
 const ddb = new DynamoDBClient({ region: process.env.AWS_DEFAULT_REGION });
+const lambda = new LambdaClient({ region: process.env.AWS_DEFAULT_REGION });
 
 const BUCKET = process.env.PHOTO_BUCKET;
 const TABLE = process.env.PHOTO_TABLE;
@@ -92,6 +94,20 @@ async function handleUpload(event) {
   if (memo) item.memo = { S: memo };
   await ddb.send(new PutItemCommand({ TableName: TABLE, Item: item }));
 
+  // U-P2: 類似サジェスト用の埋め込みを enrich Lambda(写真モード)で非同期生成。
+  // 絵の upload と同じ fire-and-forget — 失敗してもアップロードは成功扱い。
+  if (process.env.ENRICH_FUNCTION_NAME) {
+    try {
+      await lambda.send(new InvokeCommand({
+        FunctionName: process.env.ENRICH_FUNCTION_NAME,
+        InvocationType: 'Event',
+        Payload: Buffer.from(JSON.stringify({ imageId: key, kind: 'photo', now })),
+      }));
+    } catch (e) {
+      console.error('enrich invoke failed (photo upload succeeded):', e);
+    }
+  }
+
   return respond(200, { photoId: key });
 }
 
@@ -105,19 +121,57 @@ async function handleList() {
   } while (lastKey);
 
   // 新しい順に返し、各写真に閲覧用の presigned URL を付ける（署名はローカル計算なので軽い）。
+  // U-P2: 類似サジェスト用に embedding(ブラウザ内コサイン用)と linkedImages(紐づけ済みの絵)も返す。
+  // このエンドポイントは管理者限定なので、非公開の embedding を返しても公開経路には出ない。
   items.sort((a, b) => Number(b.uploadedAt && b.uploadedAt.N || 0) - Number(a.uploadedAt && a.uploadedAt.N || 0));
-  const photos = await Promise.all(items.map(async (it) => ({
-    photoId: it.photoId.S,
-    uploadedAt: it.uploadedAt && it.uploadedAt.N ? Number(it.uploadedAt.N) : null,
-    memo: (it.memo && it.memo.S) || '',
-    url: await getSignedUrl(
-      s3,
-      new GetObjectCommand({ Bucket: BUCKET, Key: it.photoId.S }),
-      { expiresIn: PRESIGN_TTL_SECONDS },
-    ),
-  })));
+  const photos = await Promise.all(items.map(async (it) => {
+    let embedding = null;
+    if (it.embedding && it.embedding.S) {
+      try { embedding = JSON.parse(it.embedding.S); } catch (e) { /* 壊れていてもサジェスト不可になるだけ */ }
+    }
+    return {
+      photoId: it.photoId.S,
+      uploadedAt: it.uploadedAt && it.uploadedAt.N ? Number(it.uploadedAt.N) : null,
+      memo: (it.memo && it.memo.S) || '',
+      embedding,
+      linkedImages: (it.linkedImages && it.linkedImages.SS) || [],
+      url: await getSignedUrl(
+        s3,
+        new GetObjectCommand({ Bucket: BUCKET, Key: it.photoId.S }),
+        { expiresIn: PRESIGN_TTL_SECONDS },
+      ),
+    };
+  }));
 
   return respond(200, { photos, expiresIn: PRESIGN_TTL_SECONDS });
+}
+
+const IMAGE_KEY_RE = /\.(png|jpe?g|gif|webp)$/i;
+
+/**
+ * U-P2: 写真↔絵の紐づけ。両テーブルに相互保存する（表示時にどちら側からも辿れるように）。
+ *  - 追加: 写真.linkedImages に imageId を ADD / 絵.refPhotos に photoId を ADD
+ *  - 解除: それぞれ DELETE
+ * 絵側の refPhotos は公開射影(update-images)が拾わない属性なので公開JSONには出ない。
+ */
+async function handleLink(key, imageId, add) {
+  if (!imageId || imageId.includes('/') || !IMAGE_KEY_RE.test(imageId)) {
+    return respond(400, { error: 'Invalid image key' });
+  }
+  const op = add ? 'ADD' : 'DELETE';
+  await ddb.send(new UpdateItemCommand({
+    TableName: TABLE,
+    Key: { photoId: { S: key } },
+    UpdateExpression: `${op} linkedImages :i`,
+    ExpressionAttributeValues: { ':i': { SS: [imageId] } },
+  }));
+  await ddb.send(new UpdateItemCommand({
+    TableName: process.env.IMAGE_METADATA_TABLE,
+    Key: { imageId: { S: imageId } },
+    UpdateExpression: `${op} refPhotos :p`,
+    ExpressionAttributeValues: { ':p': { SS: [key] } },
+  }));
+  return respond(200, { photoId: key, imageId, linked: add });
 }
 
 async function handleMemoUpdate(key, event) {
@@ -127,6 +181,11 @@ async function handleMemoUpdate(key, event) {
   } catch (e) {
     return respond(400, { error: 'Invalid JSON body' });
   }
+
+  // 紐づけ操作（linkImageAdd / linkImageRemove）はメモ更新と排他のリクエスト。
+  if (typeof parsed.linkImageAdd === 'string') return handleLink(key, parsed.linkImageAdd, true);
+  if (typeof parsed.linkImageRemove === 'string') return handleLink(key, parsed.linkImageRemove, false);
+
   const memo = typeof parsed.memo === 'string' ? parsed.memo : '';
   if (memo.length > MAX_MEMO_CHARS) {
     return respond(400, { error: `memo too long (max ${MAX_MEMO_CHARS} chars)` });

--- a/terraform/lambda-functions/photos/package-lock.json
+++ b/terraform/lambda-functions/photos/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.700.0",
+        "@aws-sdk/client-lambda": "^3.700.0",
         "@aws-sdk/client-s3": "^3.700.0",
         "@aws-sdk/s3-request-presigner": "^3.700.0"
       }
@@ -39,6 +40,25 @@
         "@aws-sdk/credential-provider-node": "^3.972.66",
         "@aws-sdk/dynamodb-codec": "^3.973.31",
         "@aws-sdk/middleware-endpoint-discovery": "^3.972.23",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.1085.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1085.0.tgz",
+      "integrity": "sha512-Ms41fQmgYK/iF89KLoLVxSwPGtCwIYGyH+1Ovm6l7jiubxDmUfzU7keLzZHOymfxfDz5bBcqfwID65fuMKEnYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-node": "^3.972.66",
         "@aws-sdk/types": "^3.974.0",
         "@smithy/core": "^3.29.2",
         "@smithy/fetch-http-handler": "^5.6.4",

--- a/terraform/lambda-functions/photos/package.json
+++ b/terraform/lambda-functions/photos/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.700.0",
     "@aws-sdk/client-dynamodb": "^3.700.0",
-    "@aws-sdk/s3-request-presigner": "^3.700.0"
+    "@aws-sdk/s3-request-presigner": "^3.700.0",
+    "@aws-sdk/client-lambda": "^3.700.0"
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -431,14 +431,15 @@ resource "aws_iam_role" "enrich_lambda_execution" {
       Version = "2012-10-17"
       Statement = [
         {
+          # 写真バケットは U-P2 の写真モード(埋め込み生成)用
           Effect   = "Allow"
           Action   = ["s3:GetObject"]
-          Resource = "${aws_s3_bucket.image_bucket.arn}/*"
+          Resource = ["${aws_s3_bucket.image_bucket.arn}/*", "${aws_s3_bucket.photo_bucket.arn}/*"]
         },
         {
           Effect   = "Allow"
           Action   = ["dynamodb:UpdateItem"]
-          Resource = aws_dynamodb_table.image_metadata.arn
+          Resource = [aws_dynamodb_table.image_metadata.arn, aws_dynamodb_table.photo_metadata.arn]
         },
         {
           # Bedrock呼び出し。モデルIDが変数(オンデマンド/推論プロファイル両対応)のため、
@@ -508,6 +509,9 @@ resource "aws_lambda_function" "image_enrich" {
       EMBED_MODEL_ID      = var.bedrock_embed_model_id
       TAG_MODEL_ID        = var.bedrock_tag_model_id
       EMBEDDING_DIMENSION = tostring(var.embedding_dimension)
+      # U-P2: 写真モード(kind=photo)の対象。類似サジェスト用の埋め込みのみ生成する。
+      PHOTO_BUCKET = aws_s3_bucket.photo_bucket.id
+      PHOTO_TABLE  = aws_dynamodb_table.photo_metadata.name
     }
   }
 

--- a/terraform/photos.tf
+++ b/terraform/photos.tf
@@ -148,6 +148,18 @@ resource "aws_iam_role" "photos_lambda_execution" {
           Resource = aws_dynamodb_table.photo_metadata.arn
         },
         {
+          # U-P2: 絵↔写真リンクの相互保存で絵側 refPhotos を更新する
+          Effect   = "Allow"
+          Action   = ["dynamodb:UpdateItem"]
+          Resource = aws_dynamodb_table.image_metadata.arn
+        },
+        {
+          # U-P2: アップロード後に enrich(写真モード)を非同期invoke して埋め込み生成
+          Effect   = "Allow"
+          Action   = ["lambda:InvokeFunction"]
+          Resource = aws_lambda_function.image_enrich.arn
+        },
+        {
           Effect   = "Allow"
           Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
           Resource = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.stack_name}-PhotosFunction:*"
@@ -172,9 +184,11 @@ resource "aws_lambda_function" "photos" {
 
   environment {
     variables = {
-      PHOTO_BUCKET   = aws_s3_bucket.photo_bucket.id
-      PHOTO_TABLE    = aws_dynamodb_table.photo_metadata.name
-      ALLOWED_ORIGIN = var.admin_allowed_origin
+      PHOTO_BUCKET         = aws_s3_bucket.photo_bucket.id
+      PHOTO_TABLE          = aws_dynamodb_table.photo_metadata.name
+      ALLOWED_ORIGIN       = var.admin_allowed_origin
+      IMAGE_METADATA_TABLE = aws_dynamodb_table.image_metadata.name         # U-P2 リンク相互保存
+      ENRICH_FUNCTION_NAME = aws_lambda_function.image_enrich.function_name # U-P2 埋め込み生成
     }
   }
 

--- a/viewer-react/src/components/ImageGallery.jsx
+++ b/viewer-react/src/components/ImageGallery.jsx
@@ -36,6 +36,8 @@ const ImageGallery = () => {
   const [memoEditor, setMemoEditor] = useState(null); // null=閉/{imageId,memo,visibility,loading,saving,error}
   // U-P1 リファレンス写真ビュー（管理モード限定）: 'images' | 'photos'
   const [viewMode, setViewMode] = useState('images');
+  // U-P2: 絵モーダルに紐づく参照写真を出すための photoId -> presigned URL マップ（管理モード時に遅延取得）
+  const [photoUrlMap, setPhotoUrlMap] = useState(null);
 
   // 設定
   const BASE_URL = "https://d3a21s3joww9j4.cloudfront.net/";
@@ -71,11 +73,35 @@ const ImageGallery = () => {
         const data = await res.json();
         const map = {};
         for (const m of (data && Array.isArray(data.memos)) ? data.memos : []) {
-          if (m && m.imageId && m.memo) map[m.imageId] = { memo: m.memo, visibility: m.visibility || 'private' };
+          if (m && m.imageId && (m.memo || (m.refPhotos && m.refPhotos.length))) {
+            map[m.imageId] = { memo: m.memo || '', visibility: m.visibility || 'private', refPhotos: m.refPhotos || [] };
+          }
         }
         if (!cancelled) setAdminMemos(map);
       } catch (e) {
         console.warn('メモ一覧の取得に失敗（公開メモのみ表示で継続）', e);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [admin]);
+
+  // U-P2: 管理モード中、紐づき表示用に写真の presigned URL マップを一度だけ取得。
+  // （URLは10分で失効するが、絵モーダルでの表示用途では再ログイン/再読込で足りる）
+  useEffect(() => {
+    if (!admin) { setPhotoUrlMap(null); return; }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`${API_BASE}/photos`, {
+          headers: { 'Authorization': 'Basic ' + btoa(`${admin.username}:${admin.password}`) },
+        });
+        if (!res.ok) return; // 写真表示は補助機能。失敗しても絵のUIは成立させる
+        const data = await res.json();
+        const map = {};
+        for (const p of (data && Array.isArray(data.photos)) ? data.photos : []) map[p.photoId] = p.url;
+        if (!cancelled) setPhotoUrlMap(map);
+      } catch (e) {
+        console.warn('写真URLマップの取得に失敗（絵モーダルの参照写真表示なしで継続）', e);
       }
     })();
     return () => { cancelled = true; };
@@ -420,7 +446,7 @@ const ImageGallery = () => {
 
       {/* U-P1 リファレンス写真ビュー（管理モード限定）。絵のUIとは排他表示 */}
       {admin && viewMode === 'photos' ? (
-        <PhotoGallery admin={admin} apiBase={API_BASE} />
+        <PhotoGallery admin={admin} apiBase={API_BASE} baseUrl={BASE_URL} embedUrl={EMBED_URL} />
       ) : (
       <>
 
@@ -514,6 +540,12 @@ const ImageGallery = () => {
         imageUrl={modalImageUrl}
         memo={modalImageName && memosById[modalImageName] ? memosById[modalImageName].memo : ''}
         isPrivate={!!(modalImageName && memosById[modalImageName] && memosById[modalImageName].visibility === 'private')}
+        refPhotoUrls={
+          // U-P2: この絵に紐づく参照写真（管理モード時のみ。photoUrlMap 未取得なら出さない）
+          admin && photoUrlMap && modalImageName && memosById[modalImageName]
+            ? (memosById[modalImageName].refPhotos || []).map(id => photoUrlMap[id]).filter(Boolean)
+            : []
+        }
         onClose={handleModalClose}
       />
 

--- a/viewer-react/src/components/Modal.jsx
+++ b/viewer-react/src/components/Modal.jsx
@@ -1,4 +1,4 @@
-const Modal = ({ isOpen, imageUrl, memo, isPrivate, onClose }) => {
+const Modal = ({ isOpen, imageUrl, memo, isPrivate, refPhotoUrls = [], onClose }) => {
   if (!isOpen) return null;
 
   const handleBackdropClick = (e) => {
@@ -11,6 +11,21 @@ const Modal = ({ isOpen, imageUrl, memo, isPrivate, onClose }) => {
     <div className={`modal ${isOpen ? 'show' : ''}`} onClick={handleBackdropClick}>
       <div className="modal-body">
         <img src={imageUrl} alt="preview" />
+        {/* U-P2: この絵に紐づくリファレンス写真（管理モード時のみ渡ってくる・非公開） */}
+        {refPhotoUrls.length > 0 && (
+          <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap', justifyContent: 'center' }}>
+            {refPhotoUrls.map((u, i) => (
+              <img
+                key={i}
+                src={u}
+                alt={`参照写真${i + 1}`}
+                title="紐づけ済みのリファレンス写真（クリックで拡大）"
+                onClick={(e) => { e.stopPropagation(); window.open(u, '_blank', 'noopener'); }}
+                style={{ height: 72, borderRadius: 6, border: '2px solid rgba(255,255,255,0.8)', cursor: 'pointer' }}
+              />
+            ))}
+          </div>
+        )}
         {memo && (
           <div className="modal-memo">
             {isPrivate && <div className="modal-memo-private">🔒 非公開メモ（自分のみ）</div>}

--- a/viewer-react/src/components/PhotoGallery.jsx
+++ b/viewer-react/src/components/PhotoGallery.jsx
@@ -8,12 +8,15 @@ import Modal from './Modal';
 // バリュー確認は自作 check-value-app に presigned URL を ?img= で渡して別タブで開く。
 const CHECK_VALUE_APP = 'https://odayakalife.dev/check-value-app/';
 
-const PhotoGallery = ({ admin, apiBase }) => {
+const PhotoGallery = ({ admin, apiBase, baseUrl, embedUrl }) => {
   const [photos, setPhotos] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [modal, setModal] = useState(null); // {url, memo}
   const [memoEditor, setMemoEditor] = useState(null); // {photoId, memo, saving, error}
+  // U-P2 類似サジェスト: {photoId, items:[{imageId,score}], loading, error} | null
+  const [suggest, setSuggest] = useState(null);
+  const [embeddingsCache, setEmbeddingsCache] = useState(null); // 絵側ベクトル(公開embeddings.json)
 
   const authHeader = 'Basic ' + btoa(`${admin.username}:${admin.password}`);
 
@@ -48,6 +51,64 @@ const PhotoGallery = ({ admin, apiBase }) => {
       setPhotos(prev => prev.filter(p => p.photoId !== photoId));
     } catch (err) {
       alert(`削除に失敗しました: ${err.message}`);
+    }
+  };
+
+  // ---- U-P2: 絵↔写真の類似サジェスト＋手動紐づけ ----------------------------------
+
+  // コサイン類似度（ImageGalleryの意味検索と同じ・ADR-002のブラウザ内総当たり）
+  const cosine = (a, b) => {
+    let dot = 0, na = 0, nb = 0;
+    const n = Math.min(a.length, b.length);
+    for (let i = 0; i < n; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+    return na && nb ? dot / (Math.sqrt(na) * Math.sqrt(nb)) : 0;
+  };
+
+  const loadEmbeddings = async () => {
+    if (embeddingsCache) return embeddingsCache;
+    const res = await fetch(embedUrl, { method: 'GET', mode: 'cors', credentials: 'omit', headers: { 'Accept': 'application/json' } });
+    if (!res.ok) throw new Error(`embeddings.json HTTP ${res.status}`);
+    const data = await res.json();
+    const list = Array.isArray(data) ? data.filter(e => e && e.imageId && Array.isArray(e.embedding)) : [];
+    setEmbeddingsCache(list);
+    return list;
+  };
+
+  const SUGGEST_LIMIT = 12;
+
+  // 「似た絵」: この写真のベクトルと全ての絵のベクトルを比較して上位を出す
+  const openSuggest = async (p) => {
+    setSuggest({ photoId: p.photoId, items: [], loading: true, error: null });
+    try {
+      if (!p.embedding) throw new Error('この写真の埋め込みが未生成です（アップロード直後は数十秒待って「再読込」）');
+      const list = await loadEmbeddings();
+      const items = list
+        .map(e => ({ imageId: e.imageId, score: cosine(p.embedding, e.embedding) }))
+        .sort((a, b) => b.score - a.score)
+        .slice(0, SUGGEST_LIMIT);
+      setSuggest(s => s && s.photoId === p.photoId ? { ...s, items, loading: false } : s);
+    } catch (err) {
+      setSuggest(s => s && s.photoId === p.photoId ? { ...s, loading: false, error: err.message } : s);
+    }
+  };
+
+  // 紐づけ/解除（PUT /photos/{key}）。成功したらローカルの linkedImages を更新
+  const toggleLink = async (photoId, imageId, currentlyLinked) => {
+    try {
+      const res = await fetch(`${apiBase}/photos/${encodeURIComponent(photoId)}`, {
+        method: 'PUT',
+        headers: { 'Authorization': authHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify(currentlyLinked ? { linkImageRemove: imageId } : { linkImageAdd: imageId }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setPhotos(prev => prev.map(p => {
+        if (p.photoId !== photoId) return p;
+        const set = new Set(p.linkedImages || []);
+        if (currentlyLinked) set.delete(imageId); else set.add(imageId);
+        return { ...p, linkedImages: [...set] };
+      }));
+    } catch (err) {
+      alert(`紐づけの更新に失敗しました: ${err.message}`);
     }
   };
 
@@ -131,10 +192,33 @@ const PhotoGallery = ({ admin, apiBase }) => {
             >
               Value
             </button>
+            <button
+              className="ctrl-btn"
+              onClick={() => openSuggest(p)}
+              title="この写真に視覚的に似た絵を探して紐づける"
+              style={{ position: 'absolute', top: 4, left: 158, background: '#1a5276', color: '#fff', zIndex: 2, opacity: 1, visibility: 'visible' }}
+            >
+              似た絵
+            </button>
             {p.memo && (
               <div className="memo-preview" onClick={() => setModal({ url: p.url, memo: p.memo })}>
                 <span className="memo-lock" title="非公開">🔒</span>
                 {p.memo}
+              </div>
+            )}
+            {/* 紐づけ済みの絵（公開CDNのサムネイル）。クリックで絵を別タブ表示 */}
+            {(p.linkedImages || []).length > 0 && (
+              <div style={{ display: 'flex', gap: 4, padding: '4px 8px 0', flexWrap: 'wrap' }}>
+                {p.linkedImages.map(id => (
+                  <img
+                    key={id}
+                    src={baseUrl + id}
+                    alt={id}
+                    title={`紐づけ済み: ${id}`}
+                    onClick={(e) => { e.stopPropagation(); window.open(baseUrl + id, '_blank', 'noopener'); }}
+                    style={{ width: 36, height: 36, objectFit: 'cover', borderRadius: 4, border: '1px solid #ddd', cursor: 'pointer' }}
+                  />
+                ))}
               </div>
             )}
             {p.uploadedAt && <span className="date-label">{dateString(p.uploadedAt)}</span>}
@@ -149,6 +233,47 @@ const PhotoGallery = ({ admin, apiBase }) => {
         isPrivate={true}
         onClose={() => setModal(null)}
       />
+
+      {/* U-P2 類似サジェストパネル: 似ている絵の候補を出し、クリックで紐づけ/解除 */}
+      {suggest && (
+        <div
+          onClick={() => setSuggest(null)}
+          style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100 }}
+        >
+          <div
+            onClick={e => e.stopPropagation()}
+            style={{ background: '#fff', borderRadius: 8, padding: 20, width: 'min(720px, 94vw)', maxHeight: '86vh', overflowY: 'auto', boxShadow: '0 8px 30px rgba(0,0,0,0.3)' }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+              <strong>この写真に似た絵（候補をタップで紐づけ⇄解除）</strong>
+              <button style={btnStyle} onClick={() => setSuggest(null)}>閉じる</button>
+            </div>
+            {suggest.loading && <div>類似度を計算中…</div>}
+            {suggest.error && <div style={{ color: '#c0392b' }}>{suggest.error}</div>}
+            {!suggest.loading && !suggest.error && (
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))', gap: 10 }}>
+                {suggest.items.map(({ imageId, score }) => {
+                  const photo = photos.find(p => p.photoId === suggest.photoId);
+                  const linked = !!(photo && (photo.linkedImages || []).includes(imageId));
+                  return (
+                    <div
+                      key={imageId}
+                      onClick={() => toggleLink(suggest.photoId, imageId, linked)}
+                      style={{ cursor: 'pointer', border: linked ? '3px solid #2d7' : '1px solid #ddd', borderRadius: 6, overflow: 'hidden', position: 'relative' }}
+                      title={linked ? 'クリックで紐づけ解除' : 'クリックで紐づけ'}
+                    >
+                      <img src={baseUrl + imageId} alt={imageId} loading="lazy" style={{ width: '100%', display: 'block' }} />
+                      <div style={{ fontSize: '0.7rem', padding: '2px 6px', display: 'flex', justifyContent: 'space-between', background: linked ? '#e8f8ef' : '#fafafa' }}>
+                        <span>{linked ? '✓ 紐づけ済み' : `類似 ${(score * 100).toFixed(0)}%`}</span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* 撮影メモ編集（絵のメモエディタと同型・公開トグルは無い=写真は常に非公開） */}
       {memoEditor && (


### PR DESCRIPTION
## 概要
Phase 2 ユニット2(issue #21 既決「視覚的類似で自動サジェスト＋手動で確定」/ ADR-007)。

## 動き方
1. **写真アップロード時に埋め込みを自動生成**: photos Lambda が既存 enrich Lambda を**写真モード**(`{kind:'photo'}`)で非同期invoke。埋め込みのみ生成(タグなし)・写真バケット/写真テーブル対象。コスト $0.0001/枚
2. **「似た絵」ボタン**(写真タイル): 写真のベクトル × 全絵のベクトル(公開embeddings.json)を**ブラウザ内コサイン**(ADR-002と同方式)で比較 → 類似上位12件をパネル表示
3. **タップで紐づけ⇄解除**: `PUT /photos/{key}` の `linkImageAdd`/`linkImageRemove` → **両テーブルに相互保存**(写真`linkedImages` ⇄ 絵`refPhotos`)
4. **表示**: 写真タイルに紐づけ済みの絵サムネイル / 絵の拡大モーダルに紐づけ済み参照写真(管理モード時のみ・presigned)

## プライバシー
- 写真の埋め込みは**管理者限定の `GET /photos` のみ**が返す(公開JSONには出さない)
- 絵側 `refPhotos` は update-images の公開射影(明示フィールドのみ)に含まれない → 公開 metadata.json に写真IDが漏れない

## 変更
- `image-enrich/index.js`: 写真モード追加(バケット/テーブル/キー属性を切替・タグ生成スキップ)
- `photos/index.js`: アップロード後のenrich非同期invoke / 一覧に `embedding`・`linkedImages` / PUTに紐づけ操作(両テーブル更新)
- `memos/index.js`: 一覧に `refPhotos`(絵側表示用)
- Terraform: enrichに写真用env＋IAM(写真バケットGetObject・写真テーブルUpdateItem)、photosにenrich invoke＋絵テーブルUpdateItem権限
- フロント: サジェストパネル・紐づけトグル・双方向のサムネ表示

## 検証
`node --check` 3 Lambda OK / lint 0 errors / build成功。実機フローはマージ→apply後に: 写真をアップ(数十秒後に埋め込み生成)→「似た絵」→候補タップ→写真タイルに絵サムネ・絵モーダルに写真、を確認。

## 既知の割り切り(ADR-007記載)
写真削除時に絵側 refPhotos は掃除しない(表示時に解決不能IDを無視)。運用で必要になったら削除時クリーンアップを追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015GA9DSBjLQiwjyrnAB5xm9)_