### PR TITLE
fix/feat(photos,admin): ValueのCORS修正・ボタン被り修正・ブックマーク自動ログイン

### DIFF
--- a/viewer-react/src/components/Modal.jsx
+++ b/viewer-react/src/components/Modal.jsx
@@ -10,7 +10,9 @@ const Modal = ({ isOpen, imageUrl, memo, isPrivate, refPhotoUrls = [], onClose }
   return (
     <div className={`modal ${isOpen ? 'show' : ''}`} onClick={handleBackdropClick}>
       <div className="modal-body">
-        <img src={imageUrl} alt="preview" />
+        {/* crossOrigin: 写真(presigned)のキャッシュをCORS付きで統一するため(check-value-app連携のキャッシュ汚染対策)。
+            絵(CloudFront)側もCORSポリシー設定済みなので同一指定で問題ない */}
+        <img src={imageUrl} alt="preview" crossOrigin="anonymous" />
         {/* U-P2: この絵に紐づくリファレンス写真（管理モード時のみ渡ってくる・非公開） */}
         {refPhotoUrls.length > 0 && (
           <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap', justifyContent: 'center' }}>

--- a/viewer-react/src/components/PhotoGallery.jsx
+++ b/viewer-react/src/components/PhotoGallery.jsx
@@ -173,36 +173,39 @@ const PhotoGallery = ({ admin, apiBase, baseUrl, embedUrl }) => {
               crossOrigin="anonymous"
               onClick={() => setModal({ url: p.url, memo: p.memo })}
             />
-            <button
-              className="ctrl-btn"
-              onClick={() => handleDelete(p.photoId)}
-              style={{ position: 'absolute', top: 4, left: 4, background: '#c0392b', color: '#fff', zIndex: 2, opacity: 1, visibility: 'visible' }}
-            >
-              削除
-            </button>
-            <button
-              className="ctrl-btn"
-              onClick={() => setMemoEditor({ photoId: p.photoId, memo: p.memo || '', saving: false, error: null })}
-              style={{ position: 'absolute', top: 4, left: 54, background: '#2c3e50', color: '#fff', zIndex: 2, opacity: 1, visibility: 'visible' }}
-            >
-              メモ
-            </button>
-            <button
-              className="ctrl-btn"
-              onClick={() => window.open(`${CHECK_VALUE_APP}?img=${encodeURIComponent(p.url)}`, '_blank', 'noopener')}
-              title="check-value-app でバリュー確認（グレースケール/Notan/ポスタリゼーション）"
-              style={{ position: 'absolute', top: 4, left: 104, background: '#7d3c98', color: '#fff', zIndex: 2, opacity: 1, visibility: 'visible' }}
-            >
-              Value
-            </button>
-            <button
-              className="ctrl-btn"
-              onClick={() => openSuggest(p)}
-              title="この写真に視覚的に似た絵を探して紐づける"
-              style={{ position: 'absolute', top: 4, left: 158, background: '#1a5276', color: '#fff', zIndex: 2, opacity: 1, visibility: 'visible' }}
-            >
-              似た絵
-            </button>
+            {/* 操作ボタン: 固定座標だと細いタイルで重なるため、折り返すflex行に載せる */}
+            <div style={{ position: 'absolute', top: 4, left: 4, right: 4, display: 'flex', gap: 4, flexWrap: 'wrap', zIndex: 2 }}>
+              <button
+                className="ctrl-btn"
+                onClick={() => handleDelete(p.photoId)}
+                style={{ position: 'static', background: '#c0392b', color: '#fff', opacity: 1, visibility: 'visible' }}
+              >
+                削除
+              </button>
+              <button
+                className="ctrl-btn"
+                onClick={() => setMemoEditor({ photoId: p.photoId, memo: p.memo || '', saving: false, error: null })}
+                style={{ position: 'static', background: '#2c3e50', color: '#fff', opacity: 1, visibility: 'visible' }}
+              >
+                メモ
+              </button>
+              <button
+                className="ctrl-btn"
+                onClick={() => window.open(`${CHECK_VALUE_APP}?img=${encodeURIComponent(p.url)}`, '_blank', 'noopener')}
+                title="check-value-app でバリュー確認（グレースケール/Notan/ポスタリゼーション）"
+                style={{ position: 'static', background: '#7d3c98', color: '#fff', opacity: 1, visibility: 'visible' }}
+              >
+                Value
+              </button>
+              <button
+                className="ctrl-btn"
+                onClick={() => openSuggest(p)}
+                title="この写真に視覚的に似た絵を探して紐づける"
+                style={{ position: 'static', background: '#1a5276', color: '#fff', opacity: 1, visibility: 'visible' }}
+              >
+                似た絵
+              </button>
+            </div>
             {p.memo && (
               <div className="memo-preview" onClick={() => setModal({ url: p.url, memo: p.memo })}>
                 <span className="memo-lock" title="非公開">🔒</span>

--- a/viewer-react/src/components/PhotoGallery.jsx
+++ b/viewer-react/src/components/PhotoGallery.jsx
@@ -168,6 +168,9 @@ const PhotoGallery = ({ admin, apiBase, baseUrl, embedUrl }) => {
               src={p.url}
               alt={p.photoId}
               loading="lazy"
+              // crossOrigin必須: これ無しで読むとCORSヘッダ無しの応答がブラウザにキャッシュされ、
+              // 後から check-value-app が同じURLを crossOrigin で読む際にキャッシュ汚染で失敗する
+              crossOrigin="anonymous"
               onClick={() => setModal({ url: p.url, memo: p.memo })}
             />
             <button


### PR DESCRIPTION
## 内容（3件・フロントのみ / terraform差分なし）

1. **Value ボタンのCORSエラー修正**: ギャラリーが写真をcrossOrigin指定なしで読むと、CORSヘッダ無しの応答がブラウザにキャッシュされ、check-value-app が同じURLをcrossOriginで読む際にキャッシュ汚染で失敗する。`<img crossOrigin="anonymous">` に統一。**S3側のCORSは実測で正常動作を確認済み**。
2. **写真タイルのボタン被り修正**: 固定left座標だと細いタイルで「削除/メモ/Value/似た絵」が重なる → 折り返すflex行に変更。
3. **ブックマーク自動ログイン**: `#k=ユーザー名:パスワード` をURLフラグメントに付けると読み込み時に管理モードへ自動ログイン。フラグメントは**サーバに送信されないためCDN/アクセスログに残らない**（ブラウザ履歴・ブックマークには残る＝端末アクセス者は管理モードに入れる。単一ユーザー運用での許容はオーナー判断）。値が間違っていればAPIが403を返すだけで、ガードは従来どおりサーバ側Basic認証。

## 経緯
1,2 は #53 マージ後にブランチへ push してしまいマージに乗り遅れた分。3 はオーナー要望（管理URLをブクマして一発で入りたい）。

lint 0 errors / build 成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)