### PR TITLE
feat(viewer): ページ頭のタイトル・タグラインを削除

### DIFF
--- a/viewer-react/src/App.jsx
+++ b/viewer-react/src/App.jsx
@@ -4,8 +4,6 @@ import './App.css'
 function App() {
   return (
     <div className="container">
-      <h1>🎨 SketchStacker</h1>
-      <p className="subtitle">Your creative journey and artwork collection</p>
       <ImageGallery />
     </div>
   )


### PR DESCRIPTION
「🎨 SketchStacker」見出しと「Your creative journey and artwork collection」タグラインを削除し、ページ先頭からギャラリーが始まるように。フロントのみ・2行削除。lint 0 errors / build成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015GA9DSBjLQiwjyrnAB5xm9)_