### PR TITLE
feat(analytics): PostHog導入 — 絵ごとのタップ/Open/Copy計測(#59 STEP 1)

### DIFF
--- a/viewer-react/package-lock.json
+++ b/viewer-react/package-lock.json
@@ -8,6 +8,7 @@
       "name": "viewer-react",
       "version": "0.0.0",
       "dependencies": {
+        "posthog-js": "^1.406.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-masonry-css": "^1.0.16"
@@ -1021,6 +1022,31 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@posthog/browser-common": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.2.0.tgz",
+      "integrity": "sha512-w+/0/Be/x48uNM7d/M37ZimSGwhuh8WBSvx61xzKzFnuoV5HqmH7GNDhaM3E3exXoBZmWNPS8hM/Ufy8zoOQSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.44.0",
+        "@posthog/types": "^1.397.1"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.44.0.tgz",
+      "integrity": "sha512-uE+mdKvetxNQC6gWQf4MHIH8bGt+JN6z7ho0A4G3t9G1VGQTx9wHYHNwkKf3gzi+1oAXS9ej2VVY4pjWUU2PWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.397.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.397.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.397.1.tgz",
+      "integrity": "sha512-W/LpWbKVaaUnfZKuFuHa+Dg03D+fC87cM+PQbG+59JcSPW8F0JcBtSoXmpfrqbpuxUToMo+gktutrUkAb/KQBw==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.34",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.34.tgz",
@@ -1401,6 +1427,13 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.0.2.tgz",
@@ -1618,6 +1651,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1664,6 +1708,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.211",
@@ -1953,6 +2006,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+      "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2442,6 +2501,41 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.406.2",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.406.2.tgz",
+      "integrity": "sha512-HNJO6Llro79s3x/ScxGY7i+Tf/o+ctJkOc79vrnS6R1I3TzucfzfwgAip1JVnQHnkBPV4JE8hI6nUXMJdU113Q==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@posthog/browser-common": "^0.2.0",
+        "@posthog/core": "^1.44.0",
+        "@posthog/types": "^1.397.1",
+        "core-js": "^3.49.0",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.3",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2461,6 +2555,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.1.1",
@@ -2773,6 +2873,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/viewer-react/package.json
+++ b/viewer-react/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "posthog-js": "^1.406.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-masonry-css": "^1.0.16"

--- a/viewer-react/src/analytics.js
+++ b/viewer-react/src/analytics.js
@@ -1,0 +1,31 @@
+// アクセス分析(PostHog)。目的: どの絵がタップ/Open/CopyされたかをPostHogに送って集計する。
+// issue #59 参照。
+//
+// POSTHOG_KEY はPostHogの「プロジェクトAPIキー」。フロントに埋め込む前提の公開トークンで
+// (全訪問者のJSに露出する種類のもの)、イベント送信にしか使えない。リポジトリに直書きでよい。
+// 空文字の間は計測は完全に無効(何も送らない・posthogを初期化すらしない)。
+import posthog from 'posthog-js';
+
+const POSTHOG_KEY = ''; // ← issue #59 STEP 2 でオーナーのプロジェクトAPIキーを設定
+const POSTHOG_HOST = 'https://us.i.posthog.com'; // US Cloudの既定ホスト
+
+let enabled = false;
+
+/** アプリ起動時に1回呼ぶ。キー未設定なら何もしない(=計測オフ)。 */
+export function initAnalytics() {
+  if (!POSTHOG_KEY) return;
+  // init の書式は公式docsの標準形(https://posthog.com/docs/libraries/js)
+  posthog.init(POSTHOG_KEY, { api_host: POSTHOG_HOST, defaults: '2025-05-24' });
+  enabled = true;
+}
+
+/** カスタムイベント送信。未初期化なら黙って無視(計測がアプリ動作を壊さないこと最優先)。 */
+export function captureEvent(name, props) {
+  if (!enabled) return;
+  try {
+    posthog.capture(name, props);
+  } catch (e) {
+    // 計測失敗はアプリの動作に影響させない
+    console.warn('analytics capture failed', e);
+  }
+}

--- a/viewer-react/src/components/ImageGallery.jsx
+++ b/viewer-react/src/components/ImageGallery.jsx
@@ -4,6 +4,7 @@ import Modal from './Modal';
 import ContributionCalendar from './ContributionCalendar';
 import PhotoGallery from './PhotoGallery';
 import Masonry from 'react-masonry-css';
+import { captureEvent } from '../analytics.js';
 
 const ImageGallery = () => {
   const [images, setImages] = useState([]);
@@ -182,6 +183,8 @@ const ImageGallery = () => {
   };
 
   const handleImageClick = (imageUrl, imageName) => {
+    // どの絵が拡大表示(タップ)されたかを計測(issue #59)
+    captureEvent('image_tap', { imageId: imageName });
     setModalImageUrl(imageUrl);
     setModalImageName(imageName || '');
     setModalOpen(true);

--- a/viewer-react/src/components/ImageItem.jsx
+++ b/viewer-react/src/components/ImageItem.jsx
@@ -1,3 +1,5 @@
+import { captureEvent } from '../analytics.js';
+
 const ImageItem = ({ imageName, baseUrl, onImageClick, adminMode, onDelete, onMemoEdit, memoInfo }) => {
   const extractTimestamp = (name) => {
     const m = name.match(/(\d{10,13})(?=\.[A-Za-z]+$)/);
@@ -22,12 +24,16 @@ const ImageItem = ({ imageName, baseUrl, onImageClick, adminMode, onDelete, onMe
 
   const handleCopyUrl = (e) => {
     e.stopPropagation();
+    // どの絵のURLがコピーされたかを計測(issue #59)
+    captureEvent('image_copy', { imageId: imageName });
     const imageUrl = getImageUrl();
     navigator.clipboard.writeText(imageUrl);
   };
 
   const handleOpenImage = (e) => {
     e.stopPropagation();
+    // どの絵がOpenされたかを計測(issue #59)
+    captureEvent('image_open', { imageId: imageName });
     const imageUrl = getImageUrl();
     window.open(imageUrl, "_blank");
   };

--- a/viewer-react/src/main.jsx
+++ b/viewer-react/src/main.jsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { initAnalytics } from './analytics.js'
+
+initAnalytics()
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>


### PR DESCRIPTION
## 概要
issue #59 のSTEP 1。**どの絵がタップ(拡大)/Open/Copyされたか**を画像ID付きイベントとしてPostHogへ送る実装。

## 重要: このPR単体では何も起きない(安全設計)
`src/analytics.js` の `POSTHOG_KEY` が**空文字の間は初期化すらしない**(通信ゼロ・挙動不変)。キーは #59 のSTEP 0でオーナーが取得→STEP 2の1行PRで設定して初めて計測開始。**先にマージしてよい。**

## 実装
- `posthog-js` を追加(公式npm手順。[docs](https://posthog.com/docs/libraries/js))
- `src/analytics.js`: `posthog.init(key, { api_host: 'https://us.i.posthog.com', defaults: ... })` の公式標準形([config docs](https://posthog.com/docs/libraries/js/config))。captureは失敗してもアプリに影響しないようガード
- イベント3種(autocaptureは使わず明示のみ):
  - `image_tap` — タイル画像タップ(モーダル表示)時。`{imageId}`
  - `image_open` — Openボタン。`{imageId}`
  - `image_copy` — Copyボタン。`{imageId}`
- PostHog側で `imageId` でグループ化すれば「絵ごとの人気ランキング」になる

## トレードオフ(明記)
- バンドル gzip **69KB → 145KB**(posthog-js分・実測)。個人ギャラリー用途で許容判断(#59に記載)
- プロジェクトAPIキーは公開トークン(全訪問者のJSに露出する設計のもの)なのでリポジトリ直書き方針

## 検証
lint 0 errors / build成功 / キー空のため動作不変(計測コードはデッドパス)

Closes: なし(#59はSTEP 2完了まで開けておく)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015GA9DSBjLQiwjyrnAB5xm9)_